### PR TITLE
docs(docs): add WIP disclaimer and fix custom domain reset

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -6,7 +6,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'Basti',
+  title: 'Basti [Work in Progress]',
   tagline: 'Basti docs will live here',
   favicon: 'img/favicon.ico',
 

--- a/packages/docs/static/CNAME
+++ b/packages/docs/static/CNAME
@@ -1,0 +1,1 @@
+www.basti.app


### PR DESCRIPTION
## Proposed Changes

This PR adds the WIP disclaimer to the docs landing page to make it clear that the docs are still in development and fixes the custom domain reset by adding the CNAME file.

## Checklist

- [x] I cleaned up my code.
- [x] All the tests and checks passed (`npm run test`).
- [x] I have added necessary documentation and/or updated existing documentation. <!-- check if not applicable -->
- [x] I have added or modified tests to cover the changes. <!-- check if not applicable -->