### PR TITLE
fix(basti): prettify security-group-cleaner.ts

### DIFF
--- a/packages/basti/src/cleanup/security-group-cleaner.ts
+++ b/packages/basti/src/cleanup/security-group-cleaner.ts
@@ -100,7 +100,6 @@ export async function cleanupElasticacheSecurityGroups(
   }
 }
 
-
 async function cleanReplicationGroup(
   replicationGroup: ReplicationGroup,
   cacheClusters: CacheCluster[],
@@ -164,7 +163,6 @@ async function cleanElasticacheMemcachedCluster(
     });
   }
 }
-
 
 function arrayContains(arr: string[], set: Set<string>): boolean {
   return arr.some(el => set.has(el));


### PR DESCRIPTION
## Proposed Changes

This PR fixes the eslint errors caused by a couple of extra new lines in the `security-group-cleaner.ts` file.

## Related Issues/PRs

#83 

## Checklist

- [x] I cleaned up my code.
- [x] All the tests and checks passed (`npm run test`).
- [x] I have added necessary documentation and/or updated existing documentation. <!-- check if not applicable -->
- [x] I have added or modified tests to cover the changes. <!-- check if not applicable -->