### PR TITLE
fix: remove `.recommendCommands()` to fix zsh completion

### DIFF
--- a/packages/basti/src/cli/run.ts
+++ b/packages/basti/src/cli/run.ts
@@ -263,6 +263,5 @@ void yargs(hideBin(process.argv))
     ],
   ])
   .completion('completion', 'Generate completion script for your shell')
-  .recommendCommands()
   .wrap(process.stdout.columns)
   .parse();


### PR DESCRIPTION
## Proposed Changes

With this change, I can see the zsh completion output correctly

```
$ SHELL=zsh basti completion zsh
#compdef basti
###-begin-basti-completions-###
#
# yargs command completion script
#
# Installation: /opt/homebrew/bin/basti completion >> ~/.zshrc
#    or /opt/homebrew/bin/basti completion >> ~/.zprofile on OSX.
#
_basti_yargs_completions()
{
  local reply
  local si=$IFS
  IFS=$'
' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" /opt/homebrew/bin/basti --get-yargs-completions "${words[@]}"))
  IFS=$si
  _describe 'values' reply
}
compdef _basti_yargs_completions basti
###-end-basti-completions-###
```

## Related Issues/PRs

fixes #96 

relates to https://github.com/Homebrew/homebrew-core/pull/168333

## Checklist

- [ ] I cleaned up my code.
- [ ] All the tests and checks passed (`npm run test`).
- [ ] I have added necessary documentation and/or updated existing documentation. <!-- check if not applicable -->
- [ ] I have added or modified tests to cover the changes. <!-- check if not applicable -->