### PR TITLE
chore(basti-cli): update Basti CLI dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -223,6 +223,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
       "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -233,6 +234,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
       "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -242,94 +244,52 @@
     "node_modules/@aws-crypto/crc32/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-crypto/ie11-detection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
-      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@aws-crypto/sha256-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
       "dependencies": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/sha256-js": "^2.0.0",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
       "dependencies": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
-      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-crypto/util": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
-      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
-      "dependencies": {
-        "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
-      "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/client-codeartifact": {
@@ -1442,871 +1402,4547 @@
       }
     },
     "node_modules/@aws-sdk/client-ec2": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.231.0.tgz",
-      "integrity": "sha512-5fnvMXaX2eJBkAWmhor590Y1D2qLrUTQv/DnFkJu0AG3crm0nFwVterN7U1gSUmE46F+ED7Fku83t0IbND+hLA==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.645.0.tgz",
+      "integrity": "sha512-+l/eyau2XUCahOmKbhf73SYguxcZVuql/vavRz5XeBmQpM25ILCMuD2pjeRqs9rjZsDPBeDlsT2lriN1Wq7XyA==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.231.0",
-        "@aws-sdk/config-resolver": "3.231.0",
-        "@aws-sdk/credential-provider-node": "3.231.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.229.0",
-        "@aws-sdk/middleware-sdk-ec2": "3.226.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.226.0",
-        "@aws-sdk/util-defaults-mode-node": "3.231.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.226.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.645.0",
+        "@aws-sdk/client-sts": "3.645.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/credential-provider-node": "3.645.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-sdk-ec2": "3.635.0",
+        "@aws-sdk/middleware-user-agent": "3.645.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.645.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.2",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/config-resolver": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+      "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+      "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/hash-node": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+      "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+      "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+      "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/middleware-retry": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+      "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/node-http-handler": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/protocol-http": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/service-error-classification": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/smithy-client": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+      "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+      "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+      "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/util-middleware": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/util-retry": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/util-stream": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-elasticache": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-elasticache/-/client-elasticache-3.398.0.tgz",
-      "integrity": "sha512-J+yJrUGY2F0LBBg0NYtgVUZwQeQ3gWFNNdmx0ssob4atX4K0+4H3su3pGUAYOcKq5HudLHQq4N+O6G+6uKczLA==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-elasticache/-/client-elasticache-3.645.0.tgz",
+      "integrity": "sha512-dlpCmPr5RzOxepUG4u+GWvue6r4X8J5g7QJK+fbLU+e0DNTACmH6yMhAH8NbG7ikL1IQHrpkyzrYaomhP4dynQ==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.398.0",
-        "@aws-sdk/credential-provider-node": "3.398.0",
-        "@aws-sdk/middleware-host-header": "3.398.0",
-        "@aws-sdk/middleware-logger": "3.398.0",
-        "@aws-sdk/middleware-recursion-detection": "3.398.0",
-        "@aws-sdk/middleware-signing": "3.398.0",
-        "@aws-sdk/middleware-user-agent": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@aws-sdk/util-endpoints": "3.398.0",
-        "@aws-sdk/util-user-agent-browser": "3.398.0",
-        "@aws-sdk/util-user-agent-node": "3.398.0",
-        "@smithy/config-resolver": "^2.0.5",
-        "@smithy/fetch-http-handler": "^2.0.5",
-        "@smithy/hash-node": "^2.0.5",
-        "@smithy/invalid-dependency": "^2.0.5",
-        "@smithy/middleware-content-length": "^2.0.5",
-        "@smithy/middleware-endpoint": "^2.0.5",
-        "@smithy/middleware-retry": "^2.0.5",
-        "@smithy/middleware-serde": "^2.0.5",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/node-http-handler": "^2.0.5",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/smithy-client": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "@smithy/url-parser": "^2.0.5",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.5",
-        "@smithy/util-defaults-mode-node": "^2.0.5",
-        "@smithy/util-retry": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "@smithy/util-waiter": "^2.0.5",
-        "fast-xml-parser": "4.2.5",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.645.0",
+        "@aws-sdk/client-sts": "3.645.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/credential-provider-node": "3.645.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.645.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.645.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-crypto/ie11-detection": {
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/config-resolver": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+      "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+      "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/hash-node": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+      "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+      "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/is-array-buffer": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
       "dependencies": {
-        "tslib": "^1.11.1"
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+      "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-crypto/sha256-browser": {
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/middleware-retry": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+      "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/node-http-handler": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/protocol-http": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/service-error-classification": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/smithy-client": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+      "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/util-base64": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
       "dependencies": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/sha256-js": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-crypto/sha256-js": {
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/util-body-length-browser": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
       "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
+        "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-crypto/supports-web-crypto": {
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/util-body-length-node": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
       "dependencies": {
-        "tslib": "^1.11.1"
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-crypto/util": {
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-crypto/util/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/client-sso": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.398.0.tgz",
-      "integrity": "sha512-CygL0jhfibw4kmWXG/3sfZMFNjcXo66XUuPC4BqZBk8Rj5vFoxp1vZeMkDLzTIk97Nvo5J5Bh+QnXKhub6AckQ==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.398.0",
-        "@aws-sdk/middleware-logger": "3.398.0",
-        "@aws-sdk/middleware-recursion-detection": "3.398.0",
-        "@aws-sdk/middleware-user-agent": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@aws-sdk/util-endpoints": "3.398.0",
-        "@aws-sdk/util-user-agent-browser": "3.398.0",
-        "@aws-sdk/util-user-agent-node": "3.398.0",
-        "@smithy/config-resolver": "^2.0.5",
-        "@smithy/fetch-http-handler": "^2.0.5",
-        "@smithy/hash-node": "^2.0.5",
-        "@smithy/invalid-dependency": "^2.0.5",
-        "@smithy/middleware-content-length": "^2.0.5",
-        "@smithy/middleware-endpoint": "^2.0.5",
-        "@smithy/middleware-retry": "^2.0.5",
-        "@smithy/middleware-serde": "^2.0.5",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/node-http-handler": "^2.0.5",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/smithy-client": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "@smithy/url-parser": "^2.0.5",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.5",
-        "@smithy/util-defaults-mode-node": "^2.0.5",
-        "@smithy/util-retry": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/client-sts": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.398.0.tgz",
-      "integrity": "sha512-/3Pa9wLMvBZipKraq3AtbmTfXW6q9kyvhwOno64f1Fz7kFb8ijQFMGoATS70B2pGEZTlxkUqJFWDiisT6Q6dFg==",
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/credential-provider-node": "3.398.0",
-        "@aws-sdk/middleware-host-header": "3.398.0",
-        "@aws-sdk/middleware-logger": "3.398.0",
-        "@aws-sdk/middleware-recursion-detection": "3.398.0",
-        "@aws-sdk/middleware-sdk-sts": "3.398.0",
-        "@aws-sdk/middleware-signing": "3.398.0",
-        "@aws-sdk/middleware-user-agent": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@aws-sdk/util-endpoints": "3.398.0",
-        "@aws-sdk/util-user-agent-browser": "3.398.0",
-        "@aws-sdk/util-user-agent-node": "3.398.0",
-        "@smithy/config-resolver": "^2.0.5",
-        "@smithy/fetch-http-handler": "^2.0.5",
-        "@smithy/hash-node": "^2.0.5",
-        "@smithy/invalid-dependency": "^2.0.5",
-        "@smithy/middleware-content-length": "^2.0.5",
-        "@smithy/middleware-endpoint": "^2.0.5",
-        "@smithy/middleware-retry": "^2.0.5",
-        "@smithy/middleware-serde": "^2.0.5",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/node-http-handler": "^2.0.5",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/smithy-client": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "@smithy/url-parser": "^2.0.5",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.5",
-        "@smithy/util-defaults-mode-node": "^2.0.5",
-        "@smithy/util-retry": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "fast-xml-parser": "4.2.5",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.398.0.tgz",
-      "integrity": "sha512-Z8Yj5z7FroAsR6UVML+XUdlpoqEe9Dnle8c2h8/xWwIC2feTfIBhjLhRVxfbpbM1pLgBSNEcZ7U8fwq5l7ESVQ==",
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+      "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
       "dependencies": {
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.2.2",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.398.0.tgz",
-      "integrity": "sha512-AsK1lStK3nB9Cn6S6ODb1ktGh7SRejsNVQVKX3t5d3tgOaX+aX1Iwy8FzM/ZEN8uCloeRifUGIY9uQFygg5mSw==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.398.0",
-        "@aws-sdk/credential-provider-process": "3.398.0",
-        "@aws-sdk/credential-provider-sso": "3.398.0",
-        "@aws-sdk/credential-provider-web-identity": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/types": "^2.2.2",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.398.0.tgz",
-      "integrity": "sha512-odmI/DSKfuWUYeDnGTCEHBbC8/MwnF6yEq874zl6+owoVv0ZsYP8qBHfiJkYqrwg7wQ7Pi40sSAPC1rhesGwzg==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.398.0",
-        "@aws-sdk/credential-provider-ini": "3.398.0",
-        "@aws-sdk/credential-provider-process": "3.398.0",
-        "@aws-sdk/credential-provider-sso": "3.398.0",
-        "@aws-sdk/credential-provider-web-identity": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/types": "^2.2.2",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.398.0.tgz",
-      "integrity": "sha512-WrkBL1W7TXN508PA9wRXPFtzmGpVSW98gDaHEaa8GolAPHMPa5t2QcC/z/cFpglzrcVv8SA277zu9Z8tELdZhg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/types": "^2.2.2",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.398.0.tgz",
-      "integrity": "sha512-2Dl35587xbnzR/GGZqA2MnFs8+kS4wbHQO9BioU0okA+8NRueohNMdrdQmQDdSNK4BfIpFspiZmFkXFNyEAfgw==",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.398.0",
-        "@aws-sdk/token-providers": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/types": "^2.2.2",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.398.0.tgz",
-      "integrity": "sha512-iG3905Alv9pINbQ8/MIsshgqYMbWx+NDQWpxbIW3W0MkSH3iAqdVpSCteYidYX9G/jv2Um1nW3y360ib20bvNg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.2.2",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.398.0.tgz",
-      "integrity": "sha512-m+5laWdBaxIZK2ko0OwcCHJZJ5V1MgEIt8QVQ3k4/kOkN9ICjevOYmba751pHoTnbOYB7zQd6D2OT3EYEEsUcA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.398.0.tgz",
-      "integrity": "sha512-CiJjW+FL12elS6Pn7/UVjVK8HWHhXMfvHZvOwx/Qkpy340sIhkuzOO6fZEruECDTZhl2Wqn81XdJ1ZQ4pRKpCg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/types": "^2.2.2",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.398.0.tgz",
-      "integrity": "sha512-7QpOqPQAZNXDXv6vsRex4R8dLniL0E/80OPK4PPFsrCh9btEyhN9Begh4i1T+5lL28hmYkztLOkTQ2N5J3hgRQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.398.0.tgz",
-      "integrity": "sha512-+JH76XHEgfVihkY+GurohOQ5Z83zVN1nYcQzwCFnCDTh4dG4KwhnZKG+WPw6XJECocY0R+H0ivofeALHvVWJtQ==",
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/types": "^2.2.2",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.398.0.tgz",
-      "integrity": "sha512-O0KqXAix1TcvZBFt1qoFkHMUNJOSgjJTYS7lFTRKSwgsD27bdW2TM2r9R8DAccWFt5Amjkdt+eOwQMIXPGTm8w==",
-      "dependencies": {
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.2.2",
-        "@smithy/util-middleware": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.398.0.tgz",
-      "integrity": "sha512-nF1jg0L+18b5HvTcYzwyFgfZQQMELJINFqI0mi4yRKaX7T5a3aGp5RVLGGju/6tAGTuFbfBoEhkhU3kkxexPYQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.398.0",
-        "@aws-sdk/util-endpoints": "3.398.0",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/token-providers": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.398.0.tgz",
-      "integrity": "sha512-nrYgjzavGCKJL/48Vt0EL+OlIc5UZLfNGpgyUW9cv3XZwl+kXV0QB+HH0rHZZLfpbBgZ2RBIJR9uD5ieu/6hpQ==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.398.0",
-        "@aws-sdk/middleware-logger": "3.398.0",
-        "@aws-sdk/middleware-recursion-detection": "3.398.0",
-        "@aws-sdk/middleware-user-agent": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@aws-sdk/util-endpoints": "3.398.0",
-        "@aws-sdk/util-user-agent-browser": "3.398.0",
-        "@aws-sdk/util-user-agent-node": "3.398.0",
-        "@smithy/config-resolver": "^2.0.5",
-        "@smithy/fetch-http-handler": "^2.0.5",
-        "@smithy/hash-node": "^2.0.5",
-        "@smithy/invalid-dependency": "^2.0.5",
-        "@smithy/middleware-content-length": "^2.0.5",
-        "@smithy/middleware-endpoint": "^2.0.5",
-        "@smithy/middleware-retry": "^2.0.5",
-        "@smithy/middleware-serde": "^2.0.5",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/node-http-handler": "^2.0.5",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/smithy-client": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "@smithy/url-parser": "^2.0.5",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.5",
-        "@smithy/util-defaults-mode-node": "^2.0.5",
-        "@smithy/util-retry": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/types": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.398.0.tgz",
-      "integrity": "sha512-r44fkS+vsEgKCuEuTV+TIk0t0m5ZlXHNjSDYEUvzLStbbfUFiNus/YG4UCa0wOk9R7VuQI67badsvvPeVPCGDQ==",
-      "dependencies": {
-        "@smithy/types": "^2.2.2",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.398.0.tgz",
-      "integrity": "sha512-Fy0gLYAei/Rd6BrXG4baspCnWTUSd0NdokU1pZh4KlfEAEN1i8SPPgfiO5hLk7+2inqtCmqxVJlfqbMVe9k4bw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.398.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.398.0.tgz",
-      "integrity": "sha512-A3Tzx1tkDHlBT+IgxmsMCHbV8LM7SwwCozq2ZjJRx0nqw3MCrrcxQFXldHeX/gdUMO+0Oocb7HGSnVODTq+0EA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/types": "^2.2.2",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.398.0.tgz",
-      "integrity": "sha512-RTVQofdj961ej4//fEkppFf4KXqKGMTCqJYghx3G0C/MYXbg7MGl7LjfNGtJcboRE8pfHHQ/TUWBDA7RIAPPlQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-elasticache/node_modules/fast-xml-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+      "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/util-middleware": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/util-retry": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/util-stream": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elasticache/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
-        "fxparser": "src/cli/cli.js"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-iam": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.231.0.tgz",
-      "integrity": "sha512-1TJPILp/D63MTS0WBxhRb+E3GyGx6SFKV7tKkS66KPMKsn971KAJZmVUxiQbcI9n3oTGUVY4kcgvZCsRuqqHkg==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.645.0.tgz",
+      "integrity": "sha512-mjUCf2IGmazIntPtCFKaPrpENBq8b0v3xMqt3gjagcVWyP7zgza8HHMokBOnDQWmKvdeuj7a4ynvbtpNQxPb1g==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.231.0",
-        "@aws-sdk/config-resolver": "3.231.0",
-        "@aws-sdk/credential-provider-node": "3.231.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.229.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.226.0",
-        "@aws-sdk/util-defaults-mode-node": "3.231.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.226.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.645.0",
+        "@aws-sdk/client-sts": "3.645.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/credential-provider-node": "3.645.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.645.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.645.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/config-resolver": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+      "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+      "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/hash-node": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+      "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+      "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+      "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/middleware-retry": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+      "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/node-http-handler": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/protocol-http": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/service-error-classification": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/smithy-client": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+      "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+      "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+      "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-middleware": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-retry": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-stream": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-rds": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-rds/-/client-rds-3.231.0.tgz",
-      "integrity": "sha512-5FqCEbP8Yn5YHMXIFl3WUsalhM4yuaptvHYm8HAEzCEgqhLXZfBWIQACkkfd333C2b9Wu4OrwYAF8k+fB5nwvQ==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-rds/-/client-rds-3.645.0.tgz",
+      "integrity": "sha512-UQU9Kj7HZlBypn0+vYvu76/pKzZZqmRQAKNXgV7cPJ+Rx2o2I9hgCUCGVEg5/0UoU85RRqekQS3tYr+GTfnNKA==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.231.0",
-        "@aws-sdk/config-resolver": "3.231.0",
-        "@aws-sdk/credential-provider-node": "3.231.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.229.0",
-        "@aws-sdk/middleware-sdk-rds": "3.226.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.226.0",
-        "@aws-sdk/util-defaults-mode-node": "3.231.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.226.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.645.0",
+        "@aws-sdk/client-sts": "3.645.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/credential-provider-node": "3.645.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-sdk-rds": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.645.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.645.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/config-resolver": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+      "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+      "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/hash-node": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+      "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+      "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+      "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/middleware-retry": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+      "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/node-http-handler": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/protocol-http": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/service-error-classification": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/smithy-client": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+      "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+      "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+      "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/util-middleware": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/util-retry": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/util-stream": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.231.0.tgz",
-      "integrity": "sha512-NiXoWdIOxhEALLEbA6L4CqsYLRBOVlz/yPU5gsOJlO2U0zlafBwGZX7bE1S3ANnGkaOAHwQWVAAwKTqtheJy7g==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.645.0.tgz",
+      "integrity": "sha512-S1SKgvIsr4oaPK+2OiDoqxihiTlNqQytTfuUgzx8evxhgpIjdxwHZ/1GCdEQtR5X88ZU1y4ryVMyCvFVjwZjsQ==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.231.0",
-        "@aws-sdk/config-resolver": "3.231.0",
-        "@aws-sdk/credential-provider-node": "3.231.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.229.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.226.0",
-        "@aws-sdk/util-defaults-mode-node": "3.231.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.226.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.645.0",
+        "@aws-sdk/client-sts": "3.645.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/credential-provider-node": "3.645.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.645.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.645.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.2",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/config-resolver": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+      "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+      "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/hash-node": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+      "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+      "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+      "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/middleware-retry": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+      "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/node-http-handler": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/protocol-http": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/service-error-classification": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/smithy-client": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+      "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+      "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+      "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-middleware": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-retry": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-stream": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.231.0.tgz",
-      "integrity": "sha512-/q7BptaMiT6/wxW9vE/gcQuApMXio5vdTuqt77A6+mjqhNzYFfCn7RRS4BU8KEOpZObnYBKP3mYe3NDccEbMzQ==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.645.0.tgz",
+      "integrity": "sha512-2rc8TjnsNddOeKQ/pfNN7deNvGLXAeKeYtHtGDAiM2qfTKxd2sNcAsZ+JCDLyshuD4xLM5fpUyR0X8As9EAouQ==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.231.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.229.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.226.0",
-        "@aws-sdk/util-defaults-mode-node": "3.231.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.645.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.645.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.231.0.tgz",
-      "integrity": "sha512-yqEZW9/Q6VvMDMcQoE52oa/oa6F8z8cqyax7m29VpuVrncYcfELpkZKWPoaJVfierR5ysKfKiAU0acPgMpvllQ==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.645.0.tgz",
+      "integrity": "sha512-X9ULtdk3cO+1ysurEkJ1MSnu6U00qodXx+IVual+1jXX4RYY1WmQmfo7uDKf6FFkz7wW1DAqU+GJIBNQr0YH8A==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.231.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.229.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.226.0",
-        "@aws-sdk/util-defaults-mode-node": "3.231.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/credential-provider-node": "3.645.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.645.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.645.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.645.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/config-resolver": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+      "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+      "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/hash-node": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+      "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+      "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+      "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-retry": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+      "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/node-http-handler": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/protocol-http": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/service-error-classification": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/smithy-client": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+      "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+      "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+      "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-middleware": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-retry": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-stream": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/config-resolver": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+      "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+      "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/hash-node": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+      "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+      "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+      "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-retry": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+      "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/node-http-handler": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/protocol-http": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/service-error-classification": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/smithy-client": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+      "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+      "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+      "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-middleware": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-retry": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-stream": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.231.0.tgz",
-      "integrity": "sha512-5WYqlcbM49ofOFBsu28QBt3t26M5D9XynhSaswSrCzawwdNkIMYQrKOCplF5mqOy+GywVIRrFeCVVrAKPMZJxQ==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.645.0.tgz",
+      "integrity": "sha512-6azXYtvtnAsPf2ShN9vKynIYVcJOpo6IoVmoMAVgNaBJyllP+s/RORzranYZzckqfmrudSxtct4rVapjLWuAMg==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.231.0",
-        "@aws-sdk/credential-provider-node": "3.231.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.229.0",
-        "@aws-sdk/middleware-sdk-sts": "3.226.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.226.0",
-        "@aws-sdk/util-defaults-mode-node": "3.231.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.645.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/credential-provider-node": "3.645.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.645.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.645.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.231.0.tgz",
-      "integrity": "sha512-qpjV4Fw/NQ4a0p5/qwzqaShflYRlY/SPcgA7N5GTJjIjZjg3NV+5BKJSF3VeZcNKfbXq68kkn207OSCpyheYxQ==",
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "tslib": "^2.3.1"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/config-resolver": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+      "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+      "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/hash-node": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+      "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+      "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+      "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-retry": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+      "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/node-http-handler": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/protocol-http": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/service-error-classification": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/smithy-client": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+      "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+      "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+      "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-middleware": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-retry": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-stream": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.635.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.635.0.tgz",
+      "integrity": "sha512-i1x/E/sgA+liUE1XJ7rj1dhyXpAKO1UKFUcTTHXok2ARjWTvszHnSXMOsB77aPbmn0fUp1JTx2kHUAZ1LVt5Bg==",
+      "dependencies": {
+        "@smithy/core": "^2.4.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/node-http-handler": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/protocol-http": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/signature-v4": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+      "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/smithy-client": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+      "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/util-middleware": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/util-stream": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
@@ -2339,112 +5975,711 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
-      "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
-      "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "tslib": "^2.3.1"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.635.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.635.0.tgz",
+      "integrity": "sha512-iJyRgEjOCQlBMXqtwPLIKYc7Bsc6nqjrZybdMDenPDa+kmLg7xh8LxHsu9088e+2/wtLicE34FsJJIfzu3L82g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/protocol-http": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/smithy-client": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+      "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-middleware": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-stream": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.231.0.tgz",
-      "integrity": "sha512-4JJgrJg2O91Vki4m5nSQNZGX/5yAYgzG1IOjeZ+8vCDxfR+jA2O9+/Xhi2/8aDpb1da77OJ+cK1+ezzSMchIfQ==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.645.0.tgz",
+      "integrity": "sha512-LlZW0qwUwNlTaAIDCNpLbPsyXvS42pRIwF92fgtCQedmdnpN3XRUC6hcwSYI7Xru3GGKp3RnceOvsdOaRJORsw==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.226.0",
-        "@aws-sdk/credential-provider-imds": "3.226.0",
-        "@aws-sdk/credential-provider-sso": "3.231.0",
-        "@aws-sdk/credential-provider-web-identity": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.635.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.645.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.645.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+      "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.231.0.tgz",
-      "integrity": "sha512-DOojjyYdLNeBQv9+PaDXmvvww9SmcZsaL1YCl27e5larcJSMfT41vn4WRnVRu2zBI2BIi464Z8ziRRKwd2YFVg==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.645.0.tgz",
+      "integrity": "sha512-eGFFuNvLeXjCJf5OCIuSEflxUowmK+bCS+lK4M8ofsYOEGAivdx7C0UPxNjHpvM8wKd8vpMl5phTeS9BWX5jMQ==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.226.0",
-        "@aws-sdk/credential-provider-imds": "3.226.0",
-        "@aws-sdk/credential-provider-ini": "3.231.0",
-        "@aws-sdk/credential-provider-process": "3.226.0",
-        "@aws-sdk/credential-provider-sso": "3.231.0",
-        "@aws-sdk/credential-provider-web-identity": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.635.0",
+        "@aws-sdk/credential-provider-ini": "3.645.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.645.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+      "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
-      "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.231.0.tgz",
-      "integrity": "sha512-aImUD+PAqZ7A2C1ef7gskMN3KuxFT4Am1Vrl6M0oLGyrhKG2QtRT/UaXJE+Yt6d/C2qc2OsQ9j2oim7D6Qha/A==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.645.0.tgz",
+      "integrity": "sha512-d6XuChAl5NCsCrUexc6AFb4efPmb9+66iwPylKG+iMTMYgO1ackfy1Q2/f35jdn0jolkPkzKsVyfzsEVoID6ew==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.231.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/token-providers": "3.231.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso": "3.645.0",
+        "@aws-sdk/token-providers": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
-      "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+      "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.621.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
@@ -2980,517 +7215,922 @@
         "fxparser": "src/cli/cli.js"
       }
     },
-    "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
-      "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/querystring-builder": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/hash-node": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
-      "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
-      "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
-      "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
-      "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
-      "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header/node_modules/@smithy/protocol-http": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
-      "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
-      "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.229.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.229.0.tgz",
-      "integrity": "sha512-/y0BWio9b2RRH2QvRTohbuqE0vhH4IZKlc6k+JRbGV9aSwyOzACU/L/qkGftC/W0puvgNvZYjGxmB6cGHAEZaw==",
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@smithy/protocol-http": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/service-error-classification": "3.229.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-ec2": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.226.0.tgz",
-      "integrity": "sha512-1ZXmNO5Gs/7p2KA8HYcIgcehEvzo7l4y2wtwIEOdkeT9rARwNm3IfjphrhzEY9Rl4GVbgEVaLr+RldngC8vDKw==",
+      "version": "3.635.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.635.0.tgz",
+      "integrity": "sha512-XsHvRUOqTyIV9M9uKMBS/8Hd5pW8RNTo3vlouQy1RDON8/LynevZ+RN5bo22iKrtOPM4J5j0YAcntUopWb1ljg==",
       "dependencies": {
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-format-url": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-format-url": "3.609.0",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/node-http-handler": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/protocol-http": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/signature-v4": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+      "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/smithy-client": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+      "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/util-middleware": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/util-stream": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-rds": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-rds/-/middleware-sdk-rds-3.226.0.tgz",
-      "integrity": "sha512-ETBZPJnkjAhRuoIPI6Ku1dGsyW3gHNj95TuZb8pT//e6HySOpBxlG1SSBwnpfKuZYUSE5q+hjzK/rDNzcpzbUQ==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-rds/-/middleware-sdk-rds-3.620.0.tgz",
+      "integrity": "sha512-pokuq3rMJfn8ZNUIhAKn0c1nQtvClPLzh5h1fOXAeRXmNjp+YPXQ4CIsGRcqDNO8lkUyyfV42WnPCdUZmR9zAA==",
       "dependencies": {
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-format-url": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-format-url": "3.609.0",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
-      "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+    "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
-      "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+    "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
-      "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+    "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "tslib": "^2.3.1"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
-      "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+    "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@smithy/protocol-http": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@smithy/signature-v4": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+      "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@smithy/util-middleware": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
-      "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.645.0.tgz",
+      "integrity": "sha512-NpTAtqWK+49lRuxfz7st9for80r4NriCMK0RfdJSoPFVntjsSQiQ7+2nW2XL05uVY633e9DvCAw8YatX3zd1mw==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.645.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
-      "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/protocol-http": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
-      "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/querystring-builder": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/property-provider": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
-      "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+    "node_modules/@aws-sdk/region-config-resolver/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
-      "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+    "node_modules/@aws-sdk/region-config-resolver/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
-      "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+    "node_modules/@aws-sdk/region-config-resolver/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.229.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
-      "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
-      "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+    "node_modules/@aws-sdk/region-config-resolver/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
-      "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+    "node_modules/@aws-sdk/region-config-resolver/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.226.0.tgz",
-      "integrity": "sha512-BWr1FhWSUhkSBp0TLzliD5AQBjA2Jmo9FlOOt+cBwd9BKkSGlGj+HgATYJ83Sjjg2+J6qvEZBxB78LKVHhorBw==",
+    "node_modules/@aws-sdk/region-config-resolver/node_modules/@smithy/util-middleware": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.231.0.tgz",
-      "integrity": "sha512-sxx6X/moSdukyrnoBtLxmgQQLWqixMc/qAM5yNg5lfNoGamWslH6CnT1HlxTFv71q8/1xwnvZ4LC2kbD6vDc6Q==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.231.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/url-parser": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
-      "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+    "node_modules/@aws-sdk/types/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
-      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.226.0.tgz",
-      "integrity": "sha512-chLx+6AeMSjuPsCVbI1B4Pg3jftjjcsuTsJucjo0DKBb1VSWqPCitmOILQVvKiA2Km8TSs3VcbUuOCyDExkzAg==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.231.0.tgz",
-      "integrity": "sha512-jH+9z96x8Oxv+bqBdD7x8CRvbKzM9id+VHzI9+h1oTY9J+6MkUubPshliBTQeus5pD03NBOS/2F3GX2rJ9Avuw==",
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.231.0",
-        "@aws-sdk/credential-provider-imds": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
-      "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.645.0.tgz",
+      "integrity": "sha512-Oe+xaU4ic4PB1k3pb5VTC1/MWES13IlgpaQw01bVHGfwP6Yv6zZOxizRzca2Y3E+AyR+nKD7vXtHRY+w3bi4bg==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-endpoints": "^2.0.5",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.226.0.tgz",
-      "integrity": "sha512-IhuA8iuJL1urWqZZmVzW79mHnwFEEP6rMsSKgAfMmuzowhtgk9p/sT2OVPkXk0LeZL2Ghsnw1W2JfPIs8x1qVg==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.609.0.tgz",
+      "integrity": "sha512-fuk29BI/oLQlJ7pfm6iJ4gkEpHdavffAALZwXh9eaY1vQ0ip0aKfRTiNudPoJjyyahnz5yJ1HkmlcDitlzsOrQ==",
       "dependencies": {
-        "@aws-sdk/querystring-builder": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+    "node_modules/@aws-sdk/util-format-url/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
@@ -3504,61 +8144,40 @@
         "node": ">= 12.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
-      "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-retry": {
-      "version": "3.229.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
-      "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
-      "dependencies": {
-        "@aws-sdk/service-error-classification": "3.229.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
-      "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
       "dependencies": {
-        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
-      "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -3569,37 +8188,62 @@
         }
       }
     },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-utf8-browser": {
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
       "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-waiter": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
-      "integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7269,6 +11913,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.5.tgz",
       "integrity": "sha512-byVZ2KWLMPYAZGKjRpniAzLcygJO4ruClZKdJTuB0eCB76ONFTdptBHlviHpAZXknRz7skYWPfcgO9v30A1SyA==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
@@ -7281,6 +11926,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.5.tgz",
       "integrity": "sha512-n0c2AXz+kjALY2FQr7Zy9zhYigXzboIh1AuUUVCqFBKFtdEvTwnwPXrTDoEehLiRTUHNL+4yzZ3s+D0kKYSLSg==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.2.2",
         "@smithy/util-config-provider": "^2.0.0",
@@ -7291,10 +11937,386 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.0.tgz",
+      "integrity": "sha512-cHXq+FneIF/KJbt4q4pjN186+Jf4ZB0ZOqEaZMBhT79srEyGDDBV31NqBRBjazz8ppQ1bJbDJMY9ba5wKFV36w==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/middleware-retry": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+      "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/node-http-handler": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/protocol-http": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/service-error-classification": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/smithy-client": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+      "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/url-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/util-middleware": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/util-retry": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/util-stream": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@smithy/credential-provider-imds": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.5.tgz",
       "integrity": "sha512-KFcf/e0meFkQNyteJ65f1G19sgUEY1e5zL7hyAEUPz2SEfBmC9B37WyRq87G3MEEsvmAWwCRu7nFFYUKtR3svQ==",
+      "dev": true,
       "dependencies": {
         "@smithy/node-config-provider": "^2.0.5",
         "@smithy/property-provider": "^2.0.5",
@@ -7310,6 +12332,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.3.tgz",
       "integrity": "sha512-3l/uKZBsV/6uMe2qXvh1C8ut/w6JHKgy7ic7N2QPR1SSuNWKNQBX0iVBqJpPtQz0UDeQYM4cNmwDBX+hw74EEw==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@smithy/types": "^2.2.0",
@@ -7321,6 +12344,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.5.tgz",
       "integrity": "sha512-EzFoMowdBNy1VqtvkiXgPFEdosIAt4/4bgZ8uiDiUyfhmNXq/3bV+CagPFFBsgFOR/X2XK4zFZHRsoa7PNHVVg==",
+      "dev": true,
       "dependencies": {
         "@smithy/protocol-http": "^2.0.5",
         "@smithy/querystring-builder": "^2.0.5",
@@ -7333,6 +12357,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.5.tgz",
       "integrity": "sha512-mk551hIywBITT+kXruRNXk7f8Fy7DTzBjZJSr/V6nolYKmUHIG3w5QU6nO9qPYEQGKc/yEPtkpdS28ndeG93lA==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.2.2",
         "@smithy/util-buffer-from": "^2.0.0",
@@ -7347,6 +12372,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.5.tgz",
       "integrity": "sha512-0wEi+JT0hM+UUwrJVYbqjuGFhy5agY/zXyiN7BNAJ1XoCDjU5uaNSj8ekPWsXd/d4yM6NSe8UbPd8cOc1+3oBQ==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
@@ -7367,6 +12393,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.5.tgz",
       "integrity": "sha512-E7VwV5H02fgZIUGRli4GevBCAPvkyEI/fgl9SU47nPPi3DAAX3nEtUb8xfGbXjOcJ5BdSUoWWZn42tEd/blOqA==",
+      "dev": true,
       "dependencies": {
         "@smithy/protocol-http": "^2.0.5",
         "@smithy/types": "^2.2.2",
@@ -7380,6 +12407,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.5.tgz",
       "integrity": "sha512-tyzDuoNTbsMQCq5Xkc4QOt6e2GACUllQIV8SQ5fc59FtOIV9/vbf58/GxVjZm2o8+MMbdDBANjTDZe/ijZKfyA==",
+      "dev": true,
       "dependencies": {
         "@smithy/middleware-serde": "^2.0.5",
         "@smithy/types": "^2.2.2",
@@ -7395,6 +12423,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.5.tgz",
       "integrity": "sha512-ulIfbFyzQTVnJbLjUl1CTSi0etg6tej/ekwaLp0Gn8ybUkDkKYa+uB6CF/m2J5B6meRwyJlsryR+DjaOVyiicg==",
+      "dev": true,
       "dependencies": {
         "@smithy/protocol-http": "^2.0.5",
         "@smithy/service-error-classification": "^2.0.0",
@@ -7412,6 +12441,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.5.tgz",
       "integrity": "sha512-in0AA5sous74dOfTGU9rMJBXJ0bDVNxwdXtEt5lh3FVd2sEyjhI+rqpLLRF1E4ixbw3RSEf80hfRpcPdjg4vvQ==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
@@ -7424,6 +12454,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.0.tgz",
       "integrity": "sha512-31XC1xNF65nlbc16yuh3wwTudmqs6qy4EseQUGF8A/p2m/5wdd/cnXJqpniy/XvXVwkHPz/GwV36HqzHtIKATQ==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -7435,6 +12466,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.5.tgz",
       "integrity": "sha512-LRtjV9WkhONe2lVy+ipB/l1GX60ybzBmFyeRUoLUXWKdnZ3o81jsnbKzMK8hKq8eFSWPk+Lmyx6ZzCQabGeLxg==",
+      "dev": true,
       "dependencies": {
         "@smithy/property-provider": "^2.0.5",
         "@smithy/shared-ini-file-loader": "^2.0.5",
@@ -7449,6 +12481,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.5.tgz",
       "integrity": "sha512-lZm5DZf4b3V0saUw9WTC4/du887P6cy2fUyQgQQKRRV6OseButyD5yTzeMmXE53CaXJBMBsUvvIQ0hRVxIq56w==",
+      "dev": true,
       "dependencies": {
         "@smithy/abort-controller": "^2.0.5",
         "@smithy/protocol-http": "^2.0.5",
@@ -7464,6 +12497,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.5.tgz",
       "integrity": "sha512-cAFSUhX6aiHcmpWfrCLKvwBtgN1F6A0N8qY/8yeSi0LRLmhGqsY1/YTxFE185MCVzYbqBGXVr9TBv4RUcIV4rA==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
@@ -7476,6 +12510,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.5.tgz",
       "integrity": "sha512-d2hhHj34mA2V86doiDfrsy2fNTnUOowGaf9hKb0hIPHqvcnShU4/OSc4Uf1FwHkAdYF3cFXTrj5VGUYbEuvMdw==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
@@ -7488,6 +12523,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.5.tgz",
       "integrity": "sha512-4DCX9krxLzATj+HdFPC3i8pb7XTAWzzKqSw8aTZMjXjtQY+vhe4azMAqIvbb6g7JKwIkmkRAjK6EXO3YWSnJVQ==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.2.2",
         "@smithy/util-uri-escape": "^2.0.0",
@@ -7501,6 +12537,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.5.tgz",
       "integrity": "sha512-C2stCULH0r54KBksv3AWcN8CLS3u9+WsEW8nBrvctrJ5rQTNa1waHkffpVaiKvcW2nP0aIMBPCobD/kYf/q9mA==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
@@ -7513,6 +12550,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.0.tgz",
       "integrity": "sha512-2z5Nafy1O0cTf69wKyNjGW/sNVMiqDnb4jgwfMG8ye8KnFJ5qmJpDccwIbJNhXIfbsxTg9SEec2oe1cexhMJvw==",
+      "dev": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -7521,6 +12559,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.5.tgz",
       "integrity": "sha512-Mvtk6FwMtfbKRC4YuSsIqRYp9WTxsSUJVVo2djgyhcacKGMqicHDWSAmgy3sDrKv+G/G6xTZCPwm6pJARtdxVg==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
@@ -7533,6 +12572,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.3.tgz",
       "integrity": "sha512-AZ+951EAcNqas2RTq4xQvuX4uZqPV/zCcbs7ACqpuxcjYAFU2FKRPpQHqsDN0jbJwI3Scw75xhSKcGWFf2/Olg==",
+      "dev": true,
       "dependencies": {
         "@smithy/eventstream-codec": "^2.0.3",
         "@smithy/is-array-buffer": "^2.0.0",
@@ -7551,6 +12591,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.5.tgz",
       "integrity": "sha512-kCTFr8wfOAWKDzGvfBElc6shHigWtHNhMQ1IbosjC4jOlayFyZMSs2PysKB+Ox/dhQ41KqOzgVjgiQ+PyWqHMQ==",
+      "dev": true,
       "dependencies": {
         "@smithy/middleware-stack": "^2.0.0",
         "@smithy/types": "^2.2.2",
@@ -7565,6 +12606,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.2.tgz",
       "integrity": "sha512-4PS0y1VxDnELGHGgBWlDksB2LJK8TG8lcvlWxIsgR+8vROI7Ms8h1P4FQUx+ftAX2QZv5g1CJCdhdRmQKyonyw==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -7576,6 +12618,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.5.tgz",
       "integrity": "sha512-OdMBvZhpckQSkugCXNJQCvqJ71wE7Ftxce92UOQLQ9pwF6hoS5PLL7wEfpnuEXtStzBqJYkzu1C1ZfjuFGOXAA==",
+      "dev": true,
       "dependencies": {
         "@smithy/querystring-parser": "^2.0.5",
         "@smithy/types": "^2.2.2",
@@ -7586,6 +12629,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
       "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
+      "dev": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
@@ -7598,6 +12642,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
       "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       }
@@ -7606,6 +12651,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
       "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -7629,6 +12675,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
       "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -7640,6 +12687,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.5.tgz",
       "integrity": "sha512-yciP6TPttLsj731aHTvekgyuCGXQrEAJibEwEWAh3kzaDsfGAVCuZSBlyvC2Dl3TZmHKCOQwHV8mIE7KQCTPuQ==",
+      "dev": true,
       "dependencies": {
         "@smithy/property-provider": "^2.0.5",
         "@smithy/types": "^2.2.2",
@@ -7654,6 +12702,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.5.tgz",
       "integrity": "sha512-M07t99rWasXt+IaDZDyP3BkcoEm/mgIE1RIMASrE49LKSNxaVN7PVcgGc77+4uu2kzBAyqJKy79pgtezuknyjQ==",
+      "dev": true,
       "dependencies": {
         "@smithy/config-resolver": "^2.0.5",
         "@smithy/credential-provider-imds": "^2.0.5",
@@ -7666,10 +12715,73 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.5.tgz",
+      "integrity": "sha512-ReQP0BWihIE68OAblC/WQmDD40Gx+QY1Ez8mTdFMXpmjfxSyz2fVQu3A4zXRfQU9sZXtewk3GmhfOHswvX+eNg==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints/node_modules/@smithy/property-provider": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@smithy/util-hex-encoding": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
       "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -7681,6 +12793,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.0.tgz",
       "integrity": "sha512-eCWX4ECuDHn1wuyyDdGdUWnT4OGyIzV0LN1xRttBFMPI9Ff/4heSHVxneyiMtOB//zpXWCha1/SWHJOZstG7kA==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -7692,6 +12805,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.0.tgz",
       "integrity": "sha512-/dvJ8afrElasuiiIttRJeoS2sy8YXpksQwiM/TcepqdRVp7u4ejd9C4IQURHNjlfPUT7Y6lCDSa2zQJbdHhVTg==",
+      "dev": true,
       "dependencies": {
         "@smithy/service-error-classification": "^2.0.0",
         "tslib": "^2.5.0"
@@ -7704,6 +12818,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.5.tgz",
       "integrity": "sha512-ylx27GwI05xLpYQ4hDIfS15vm+wYjNN0Sc2P0FxuzgRe8v0BOLHppGIQ+Bezcynk8C9nUzsUue3TmtRhjut43g==",
+      "dev": true,
       "dependencies": {
         "@smithy/fetch-http-handler": "^2.0.5",
         "@smithy/node-http-handler": "^2.0.5",
@@ -7722,6 +12837,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
       "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -7742,16 +12858,39 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.5.tgz",
-      "integrity": "sha512-1lkkUmI/bhaDX+LIT3RiUNAn+NzPmsWjE7beMq0oQ3H1/CffaILIN67riDA0aE1YBj6xll7uWMIy4tJqc+peXw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.2.tgz",
+      "integrity": "sha512-4pP0EV3iTsexDx+8PPGAKCQpd/6hsQBaQhqWzU4hqKPHN5epPsxKbvUTIiYIHTxaKt6/kEaqPBpu/ufvfbrRzw==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "tslib": "^2.5.0"
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter/node_modules/@smithy/abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter/node_modules/@smithy/types": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
@@ -12999,18 +18138,24 @@
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
       "dependencies": {
         "strnum": "^1.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/fastq": {
@@ -16319,19 +21464,6 @@
         "publib-npm": "bin/publib-npm",
         "publib-nuget": "bin/publib-nuget",
         "publib-pypi": "bin/publib-pypi"
-      }
-    },
-    "node_modules/jsii-release/node_modules/@aws-sdk/types": {
-      "version": "3.387.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.387.0.tgz",
-      "integrity": "sha512-YTjFabNwjTF+6yl88f0/tWff018qmmgMmjlw45s6sdVKueWxdxV68U7gepNLF2nhaQPZa6FDOBoA51NaviVs0Q==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.1.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/jsii-release/node_modules/brace-expansion": {
@@ -21383,9 +26515,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -22886,9 +28018,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.18.0.tgz",
-      "integrity": "sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA==",
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -22917,17 +28049,17 @@
       "version": "1.6.2",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-ec2": "3.231.0",
-        "@aws-sdk/client-elasticache": "3.398.0",
-        "@aws-sdk/client-iam": "3.231.0",
-        "@aws-sdk/client-rds": "3.231.0",
-        "@aws-sdk/client-ssm": "3.231.0",
+        "@aws-sdk/client-ec2": "3.645.0",
+        "@aws-sdk/client-elasticache": "3.645.0",
+        "@aws-sdk/client-iam": "3.645.0",
+        "@aws-sdk/client-rds": "3.645.0",
+        "@aws-sdk/client-ssm": "3.645.0",
         "chalk": "5.0.1",
         "cosmiconfig": "8.1.3",
         "inquirer": "9.0.0",
         "ora": "6.1.2",
         "yargs": "17.7.2",
-        "zod": "3.18.0",
+        "zod": "3.23.8",
         "zod-validation-error": "1.3.0"
       },
       "bin": {
@@ -23166,6 +28298,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
       "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dev": true,
       "requires": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -23176,6 +28309,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
           "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+          "dev": true,
           "requires": {
             "@aws-sdk/types": "^3.222.0",
             "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -23185,103 +28319,51 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-crypto/ie11-detection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
-      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
-      "requires": {
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
     "@aws-crypto/sha256-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
       "requires": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/sha256-js": "^2.0.0",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-crypto/sha256-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
       "requires": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-crypto/supports-web-crypto": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
-      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
       "requires": {
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "tslib": "^2.6.2"
       }
     },
     "@aws-crypto/util": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
-      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
       "requires": {
-        "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/abort-controller": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
-      "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
-      "requires": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/client-codeartifact": {
@@ -24262,781 +29344,3645 @@
       }
     },
     "@aws-sdk/client-ec2": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.231.0.tgz",
-      "integrity": "sha512-5fnvMXaX2eJBkAWmhor590Y1D2qLrUTQv/DnFkJu0AG3crm0nFwVterN7U1gSUmE46F+ED7Fku83t0IbND+hLA==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.645.0.tgz",
+      "integrity": "sha512-+l/eyau2XUCahOmKbhf73SYguxcZVuql/vavRz5XeBmQpM25ILCMuD2pjeRqs9rjZsDPBeDlsT2lriN1Wq7XyA==",
       "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.231.0",
-        "@aws-sdk/config-resolver": "3.231.0",
-        "@aws-sdk/credential-provider-node": "3.231.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.229.0",
-        "@aws-sdk/middleware-sdk-ec2": "3.226.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.226.0",
-        "@aws-sdk/util-defaults-mode-node": "3.231.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.226.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.645.0",
+        "@aws-sdk/client-sts": "3.645.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/credential-provider-node": "3.645.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-sdk-ec2": "3.635.0",
+        "@aws-sdk/middleware-user-agent": "3.645.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.645.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.2",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+          "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/config-resolver": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+          "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-config-provider": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/credential-provider-imds": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+          "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+          "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/hash-node": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+          "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/invalid-dependency": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+          "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+          "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-content-length": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+          "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-endpoint": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+          "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+          "requires": {
+            "@smithy/middleware-serde": "^3.0.3",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-retry": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+          "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/service-error-classification": "^3.0.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-retry": "^3.0.3",
+            "tslib": "^2.6.2",
+            "uuid": "^9.0.1"
+          }
+        },
+        "@smithy/middleware-serde": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+          "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-stack": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+          "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+          "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+          "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+          "requires": {
+            "@smithy/abort-controller": "^3.1.1",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+          "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+          "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+          "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/service-error-classification": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/smithy-client": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+          "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+          "requires": {
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-stack": "^3.0.3",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-stream": "^3.1.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+          "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+          "requires": {
+            "@smithy/querystring-parser": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-base64": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+          "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+          "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-node": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+          "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+          "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-config-provider": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+          "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-browser": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+          "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-node": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+          "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
+          "requires": {
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/credential-provider-imds": "^3.2.0",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-hex-encoding": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+          "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-middleware": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+          "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-retry": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+          "requires": {
+            "@smithy/service-error-classification": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-stream": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+          "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+          "requires": {
+            "@smithy/fetch-http-handler": "^3.2.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+          "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+          "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+        }
       }
     },
     "@aws-sdk/client-elasticache": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-elasticache/-/client-elasticache-3.398.0.tgz",
-      "integrity": "sha512-J+yJrUGY2F0LBBg0NYtgVUZwQeQ3gWFNNdmx0ssob4atX4K0+4H3su3pGUAYOcKq5HudLHQq4N+O6G+6uKczLA==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-elasticache/-/client-elasticache-3.645.0.tgz",
+      "integrity": "sha512-dlpCmPr5RzOxepUG4u+GWvue6r4X8J5g7QJK+fbLU+e0DNTACmH6yMhAH8NbG7ikL1IQHrpkyzrYaomhP4dynQ==",
       "requires": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.398.0",
-        "@aws-sdk/credential-provider-node": "3.398.0",
-        "@aws-sdk/middleware-host-header": "3.398.0",
-        "@aws-sdk/middleware-logger": "3.398.0",
-        "@aws-sdk/middleware-recursion-detection": "3.398.0",
-        "@aws-sdk/middleware-signing": "3.398.0",
-        "@aws-sdk/middleware-user-agent": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@aws-sdk/util-endpoints": "3.398.0",
-        "@aws-sdk/util-user-agent-browser": "3.398.0",
-        "@aws-sdk/util-user-agent-node": "3.398.0",
-        "@smithy/config-resolver": "^2.0.5",
-        "@smithy/fetch-http-handler": "^2.0.5",
-        "@smithy/hash-node": "^2.0.5",
-        "@smithy/invalid-dependency": "^2.0.5",
-        "@smithy/middleware-content-length": "^2.0.5",
-        "@smithy/middleware-endpoint": "^2.0.5",
-        "@smithy/middleware-retry": "^2.0.5",
-        "@smithy/middleware-serde": "^2.0.5",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/node-http-handler": "^2.0.5",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/smithy-client": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "@smithy/url-parser": "^2.0.5",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.5",
-        "@smithy/util-defaults-mode-node": "^2.0.5",
-        "@smithy/util-retry": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "@smithy/util-waiter": "^2.0.5",
-        "fast-xml-parser": "4.2.5",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.645.0",
+        "@aws-sdk/client-sts": "3.645.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/credential-provider-node": "3.645.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.645.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.645.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.2",
+        "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-crypto/ie11-detection": {
+        "@smithy/abort-controller": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+          "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/config-resolver": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+          "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-config-provider": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/credential-provider-imds": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+          "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+          "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/hash-node": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+          "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/invalid-dependency": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+          "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-          "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+          "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
           "requires": {
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
+            "tslib": "^2.6.2"
           }
         },
-        "@aws-crypto/sha256-browser": {
+        "@smithy/middleware-content-length": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+          "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-endpoint": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+          "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+          "requires": {
+            "@smithy/middleware-serde": "^3.0.3",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-retry": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+          "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/service-error-classification": "^3.0.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-retry": "^3.0.3",
+            "tslib": "^2.6.2",
+            "uuid": "^9.0.1"
+          }
+        },
+        "@smithy/middleware-serde": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+          "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-stack": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+          "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+          "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+          "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+          "requires": {
+            "@smithy/abort-controller": "^3.1.1",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+          "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+          "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+          "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/service-error-classification": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/smithy-client": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+          "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+          "requires": {
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-stack": "^3.0.3",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-stream": "^3.1.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+          "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+          "requires": {
+            "@smithy/querystring-parser": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-base64": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-          "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+          "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
           "requires": {
-            "@aws-crypto/ie11-detection": "^3.0.0",
-            "@aws-crypto/sha256-js": "^3.0.0",
-            "@aws-crypto/supports-web-crypto": "^3.0.0",
-            "@aws-crypto/util": "^3.0.0",
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-locate-window": "^3.0.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
           }
         },
-        "@aws-crypto/sha256-js": {
+        "@smithy/util-body-length-browser": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-          "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+          "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
           "requires": {
-            "@aws-crypto/util": "^3.0.0",
-            "@aws-sdk/types": "^3.222.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
+            "tslib": "^2.6.2"
           }
         },
-        "@aws-crypto/supports-web-crypto": {
+        "@smithy/util-body-length-node": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-          "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+          "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
           "requires": {
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
+            "tslib": "^2.6.2"
           }
         },
-        "@aws-crypto/util": {
+        "@smithy/util-buffer-from": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+          "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
+            "@smithy/is-array-buffer": "^3.0.0",
+            "tslib": "^2.6.2"
           }
         },
-        "@aws-sdk/client-sso": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.398.0.tgz",
-          "integrity": "sha512-CygL0jhfibw4kmWXG/3sfZMFNjcXo66XUuPC4BqZBk8Rj5vFoxp1vZeMkDLzTIk97Nvo5J5Bh+QnXKhub6AckQ==",
+        "@smithy/util-config-provider": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+          "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
           "requires": {
-            "@aws-crypto/sha256-browser": "3.0.0",
-            "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/middleware-host-header": "3.398.0",
-            "@aws-sdk/middleware-logger": "3.398.0",
-            "@aws-sdk/middleware-recursion-detection": "3.398.0",
-            "@aws-sdk/middleware-user-agent": "3.398.0",
-            "@aws-sdk/types": "3.398.0",
-            "@aws-sdk/util-endpoints": "3.398.0",
-            "@aws-sdk/util-user-agent-browser": "3.398.0",
-            "@aws-sdk/util-user-agent-node": "3.398.0",
-            "@smithy/config-resolver": "^2.0.5",
-            "@smithy/fetch-http-handler": "^2.0.5",
-            "@smithy/hash-node": "^2.0.5",
-            "@smithy/invalid-dependency": "^2.0.5",
-            "@smithy/middleware-content-length": "^2.0.5",
-            "@smithy/middleware-endpoint": "^2.0.5",
-            "@smithy/middleware-retry": "^2.0.5",
-            "@smithy/middleware-serde": "^2.0.5",
-            "@smithy/middleware-stack": "^2.0.0",
-            "@smithy/node-config-provider": "^2.0.5",
-            "@smithy/node-http-handler": "^2.0.5",
-            "@smithy/protocol-http": "^2.0.5",
-            "@smithy/smithy-client": "^2.0.5",
-            "@smithy/types": "^2.2.2",
-            "@smithy/url-parser": "^2.0.5",
-            "@smithy/util-base64": "^2.0.0",
-            "@smithy/util-body-length-browser": "^2.0.0",
-            "@smithy/util-body-length-node": "^2.1.0",
-            "@smithy/util-defaults-mode-browser": "^2.0.5",
-            "@smithy/util-defaults-mode-node": "^2.0.5",
-            "@smithy/util-retry": "^2.0.0",
-            "@smithy/util-utf8": "^2.0.0",
-            "tslib": "^2.5.0"
+            "tslib": "^2.6.2"
           }
         },
-        "@aws-sdk/client-sts": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.398.0.tgz",
-          "integrity": "sha512-/3Pa9wLMvBZipKraq3AtbmTfXW6q9kyvhwOno64f1Fz7kFb8ijQFMGoATS70B2pGEZTlxkUqJFWDiisT6Q6dFg==",
+        "@smithy/util-defaults-mode-browser": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+          "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
           "requires": {
-            "@aws-crypto/sha256-browser": "3.0.0",
-            "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/credential-provider-node": "3.398.0",
-            "@aws-sdk/middleware-host-header": "3.398.0",
-            "@aws-sdk/middleware-logger": "3.398.0",
-            "@aws-sdk/middleware-recursion-detection": "3.398.0",
-            "@aws-sdk/middleware-sdk-sts": "3.398.0",
-            "@aws-sdk/middleware-signing": "3.398.0",
-            "@aws-sdk/middleware-user-agent": "3.398.0",
-            "@aws-sdk/types": "3.398.0",
-            "@aws-sdk/util-endpoints": "3.398.0",
-            "@aws-sdk/util-user-agent-browser": "3.398.0",
-            "@aws-sdk/util-user-agent-node": "3.398.0",
-            "@smithy/config-resolver": "^2.0.5",
-            "@smithy/fetch-http-handler": "^2.0.5",
-            "@smithy/hash-node": "^2.0.5",
-            "@smithy/invalid-dependency": "^2.0.5",
-            "@smithy/middleware-content-length": "^2.0.5",
-            "@smithy/middleware-endpoint": "^2.0.5",
-            "@smithy/middleware-retry": "^2.0.5",
-            "@smithy/middleware-serde": "^2.0.5",
-            "@smithy/middleware-stack": "^2.0.0",
-            "@smithy/node-config-provider": "^2.0.5",
-            "@smithy/node-http-handler": "^2.0.5",
-            "@smithy/protocol-http": "^2.0.5",
-            "@smithy/smithy-client": "^2.0.5",
-            "@smithy/types": "^2.2.2",
-            "@smithy/url-parser": "^2.0.5",
-            "@smithy/util-base64": "^2.0.0",
-            "@smithy/util-body-length-browser": "^2.0.0",
-            "@smithy/util-body-length-node": "^2.1.0",
-            "@smithy/util-defaults-mode-browser": "^2.0.5",
-            "@smithy/util-defaults-mode-node": "^2.0.5",
-            "@smithy/util-retry": "^2.0.0",
-            "@smithy/util-utf8": "^2.0.0",
-            "fast-xml-parser": "4.2.5",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-env": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.398.0.tgz",
-          "integrity": "sha512-Z8Yj5z7FroAsR6UVML+XUdlpoqEe9Dnle8c2h8/xWwIC2feTfIBhjLhRVxfbpbM1pLgBSNEcZ7U8fwq5l7ESVQ==",
-          "requires": {
-            "@aws-sdk/types": "3.398.0",
-            "@smithy/property-provider": "^2.0.0",
-            "@smithy/types": "^2.2.2",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.398.0.tgz",
-          "integrity": "sha512-AsK1lStK3nB9Cn6S6ODb1ktGh7SRejsNVQVKX3t5d3tgOaX+aX1Iwy8FzM/ZEN8uCloeRifUGIY9uQFygg5mSw==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.398.0",
-            "@aws-sdk/credential-provider-process": "3.398.0",
-            "@aws-sdk/credential-provider-sso": "3.398.0",
-            "@aws-sdk/credential-provider-web-identity": "3.398.0",
-            "@aws-sdk/types": "3.398.0",
-            "@smithy/credential-provider-imds": "^2.0.0",
-            "@smithy/property-provider": "^2.0.0",
-            "@smithy/shared-ini-file-loader": "^2.0.0",
-            "@smithy/types": "^2.2.2",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.398.0.tgz",
-          "integrity": "sha512-odmI/DSKfuWUYeDnGTCEHBbC8/MwnF6yEq874zl6+owoVv0ZsYP8qBHfiJkYqrwg7wQ7Pi40sSAPC1rhesGwzg==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.398.0",
-            "@aws-sdk/credential-provider-ini": "3.398.0",
-            "@aws-sdk/credential-provider-process": "3.398.0",
-            "@aws-sdk/credential-provider-sso": "3.398.0",
-            "@aws-sdk/credential-provider-web-identity": "3.398.0",
-            "@aws-sdk/types": "3.398.0",
-            "@smithy/credential-provider-imds": "^2.0.0",
-            "@smithy/property-provider": "^2.0.0",
-            "@smithy/shared-ini-file-loader": "^2.0.0",
-            "@smithy/types": "^2.2.2",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.398.0.tgz",
-          "integrity": "sha512-WrkBL1W7TXN508PA9wRXPFtzmGpVSW98gDaHEaa8GolAPHMPa5t2QcC/z/cFpglzrcVv8SA277zu9Z8tELdZhg==",
-          "requires": {
-            "@aws-sdk/types": "3.398.0",
-            "@smithy/property-provider": "^2.0.0",
-            "@smithy/shared-ini-file-loader": "^2.0.0",
-            "@smithy/types": "^2.2.2",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.398.0.tgz",
-          "integrity": "sha512-2Dl35587xbnzR/GGZqA2MnFs8+kS4wbHQO9BioU0okA+8NRueohNMdrdQmQDdSNK4BfIpFspiZmFkXFNyEAfgw==",
-          "requires": {
-            "@aws-sdk/client-sso": "3.398.0",
-            "@aws-sdk/token-providers": "3.398.0",
-            "@aws-sdk/types": "3.398.0",
-            "@smithy/property-provider": "^2.0.0",
-            "@smithy/shared-ini-file-loader": "^2.0.0",
-            "@smithy/types": "^2.2.2",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.398.0.tgz",
-          "integrity": "sha512-iG3905Alv9pINbQ8/MIsshgqYMbWx+NDQWpxbIW3W0MkSH3iAqdVpSCteYidYX9G/jv2Um1nW3y360ib20bvNg==",
-          "requires": {
-            "@aws-sdk/types": "3.398.0",
-            "@smithy/property-provider": "^2.0.0",
-            "@smithy/types": "^2.2.2",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-host-header": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.398.0.tgz",
-          "integrity": "sha512-m+5laWdBaxIZK2ko0OwcCHJZJ5V1MgEIt8QVQ3k4/kOkN9ICjevOYmba751pHoTnbOYB7zQd6D2OT3EYEEsUcA==",
-          "requires": {
-            "@aws-sdk/types": "3.398.0",
-            "@smithy/protocol-http": "^2.0.5",
-            "@smithy/types": "^2.2.2",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-logger": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.398.0.tgz",
-          "integrity": "sha512-CiJjW+FL12elS6Pn7/UVjVK8HWHhXMfvHZvOwx/Qkpy340sIhkuzOO6fZEruECDTZhl2Wqn81XdJ1ZQ4pRKpCg==",
-          "requires": {
-            "@aws-sdk/types": "3.398.0",
-            "@smithy/types": "^2.2.2",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.398.0.tgz",
-          "integrity": "sha512-7QpOqPQAZNXDXv6vsRex4R8dLniL0E/80OPK4PPFsrCh9btEyhN9Begh4i1T+5lL28hmYkztLOkTQ2N5J3hgRQ==",
-          "requires": {
-            "@aws-sdk/types": "3.398.0",
-            "@smithy/protocol-http": "^2.0.5",
-            "@smithy/types": "^2.2.2",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-sdk-sts": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.398.0.tgz",
-          "integrity": "sha512-+JH76XHEgfVihkY+GurohOQ5Z83zVN1nYcQzwCFnCDTh4dG4KwhnZKG+WPw6XJECocY0R+H0ivofeALHvVWJtQ==",
-          "requires": {
-            "@aws-sdk/middleware-signing": "3.398.0",
-            "@aws-sdk/types": "3.398.0",
-            "@smithy/types": "^2.2.2",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-signing": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.398.0.tgz",
-          "integrity": "sha512-O0KqXAix1TcvZBFt1qoFkHMUNJOSgjJTYS7lFTRKSwgsD27bdW2TM2r9R8DAccWFt5Amjkdt+eOwQMIXPGTm8w==",
-          "requires": {
-            "@aws-sdk/types": "3.398.0",
-            "@smithy/property-provider": "^2.0.0",
-            "@smithy/protocol-http": "^2.0.5",
-            "@smithy/signature-v4": "^2.0.0",
-            "@smithy/types": "^2.2.2",
-            "@smithy/util-middleware": "^2.0.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-user-agent": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.398.0.tgz",
-          "integrity": "sha512-nF1jg0L+18b5HvTcYzwyFgfZQQMELJINFqI0mi4yRKaX7T5a3aGp5RVLGGju/6tAGTuFbfBoEhkhU3kkxexPYQ==",
-          "requires": {
-            "@aws-sdk/types": "3.398.0",
-            "@aws-sdk/util-endpoints": "3.398.0",
-            "@smithy/protocol-http": "^2.0.5",
-            "@smithy/types": "^2.2.2",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.398.0.tgz",
-          "integrity": "sha512-nrYgjzavGCKJL/48Vt0EL+OlIc5UZLfNGpgyUW9cv3XZwl+kXV0QB+HH0rHZZLfpbBgZ2RBIJR9uD5ieu/6hpQ==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "3.0.0",
-            "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/middleware-host-header": "3.398.0",
-            "@aws-sdk/middleware-logger": "3.398.0",
-            "@aws-sdk/middleware-recursion-detection": "3.398.0",
-            "@aws-sdk/middleware-user-agent": "3.398.0",
-            "@aws-sdk/types": "3.398.0",
-            "@aws-sdk/util-endpoints": "3.398.0",
-            "@aws-sdk/util-user-agent-browser": "3.398.0",
-            "@aws-sdk/util-user-agent-node": "3.398.0",
-            "@smithy/config-resolver": "^2.0.5",
-            "@smithy/fetch-http-handler": "^2.0.5",
-            "@smithy/hash-node": "^2.0.5",
-            "@smithy/invalid-dependency": "^2.0.5",
-            "@smithy/middleware-content-length": "^2.0.5",
-            "@smithy/middleware-endpoint": "^2.0.5",
-            "@smithy/middleware-retry": "^2.0.5",
-            "@smithy/middleware-serde": "^2.0.5",
-            "@smithy/middleware-stack": "^2.0.0",
-            "@smithy/node-config-provider": "^2.0.5",
-            "@smithy/node-http-handler": "^2.0.5",
-            "@smithy/property-provider": "^2.0.0",
-            "@smithy/protocol-http": "^2.0.5",
-            "@smithy/shared-ini-file-loader": "^2.0.0",
-            "@smithy/smithy-client": "^2.0.5",
-            "@smithy/types": "^2.2.2",
-            "@smithy/url-parser": "^2.0.5",
-            "@smithy/util-base64": "^2.0.0",
-            "@smithy/util-body-length-browser": "^2.0.0",
-            "@smithy/util-body-length-node": "^2.1.0",
-            "@smithy/util-defaults-mode-browser": "^2.0.5",
-            "@smithy/util-defaults-mode-node": "^2.0.5",
-            "@smithy/util-retry": "^2.0.0",
-            "@smithy/util-utf8": "^2.0.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.398.0.tgz",
-          "integrity": "sha512-r44fkS+vsEgKCuEuTV+TIk0t0m5ZlXHNjSDYEUvzLStbbfUFiNus/YG4UCa0wOk9R7VuQI67badsvvPeVPCGDQ==",
-          "requires": {
-            "@smithy/types": "^2.2.2",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.398.0.tgz",
-          "integrity": "sha512-Fy0gLYAei/Rd6BrXG4baspCnWTUSd0NdokU1pZh4KlfEAEN1i8SPPgfiO5hLk7+2inqtCmqxVJlfqbMVe9k4bw==",
-          "requires": {
-            "@aws-sdk/types": "3.398.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-user-agent-browser": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.398.0.tgz",
-          "integrity": "sha512-A3Tzx1tkDHlBT+IgxmsMCHbV8LM7SwwCozq2ZjJRx0nqw3MCrrcxQFXldHeX/gdUMO+0Oocb7HGSnVODTq+0EA==",
-          "requires": {
-            "@aws-sdk/types": "3.398.0",
-            "@smithy/types": "^2.2.2",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
             "bowser": "^2.11.0",
-            "tslib": "^2.5.0"
+            "tslib": "^2.6.2"
           }
         },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.398.0.tgz",
-          "integrity": "sha512-RTVQofdj961ej4//fEkppFf4KXqKGMTCqJYghx3G0C/MYXbg7MGl7LjfNGtJcboRE8pfHHQ/TUWBDA7RIAPPlQ==",
+        "@smithy/util-defaults-mode-node": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+          "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
           "requires": {
-            "@aws-sdk/types": "3.398.0",
-            "@smithy/node-config-provider": "^2.0.5",
-            "@smithy/types": "^2.2.2",
-            "tslib": "^2.5.0"
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/credential-provider-imds": "^3.2.0",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
           }
         },
-        "fast-xml-parser": {
-          "version": "4.2.5",
-          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-          "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+        "@smithy/util-hex-encoding": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+          "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
           "requires": {
-            "strnum": "^1.0.5"
+            "tslib": "^2.6.2"
           }
+        },
+        "@smithy/util-middleware": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+          "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-retry": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+          "requires": {
+            "@smithy/service-error-classification": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-stream": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+          "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+          "requires": {
+            "@smithy/fetch-http-handler": "^3.2.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+          "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+          "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
         }
       }
     },
     "@aws-sdk/client-iam": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.231.0.tgz",
-      "integrity": "sha512-1TJPILp/D63MTS0WBxhRb+E3GyGx6SFKV7tKkS66KPMKsn971KAJZmVUxiQbcI9n3oTGUVY4kcgvZCsRuqqHkg==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.645.0.tgz",
+      "integrity": "sha512-mjUCf2IGmazIntPtCFKaPrpENBq8b0v3xMqt3gjagcVWyP7zgza8HHMokBOnDQWmKvdeuj7a4ynvbtpNQxPb1g==",
       "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.231.0",
-        "@aws-sdk/config-resolver": "3.231.0",
-        "@aws-sdk/credential-provider-node": "3.231.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.229.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.226.0",
-        "@aws-sdk/util-defaults-mode-node": "3.231.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.226.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.645.0",
+        "@aws-sdk/client-sts": "3.645.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/credential-provider-node": "3.645.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.645.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.645.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.2",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+          "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/config-resolver": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+          "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-config-provider": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/credential-provider-imds": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+          "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+          "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/hash-node": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+          "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/invalid-dependency": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+          "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+          "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-content-length": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+          "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-endpoint": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+          "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+          "requires": {
+            "@smithy/middleware-serde": "^3.0.3",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-retry": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+          "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/service-error-classification": "^3.0.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-retry": "^3.0.3",
+            "tslib": "^2.6.2",
+            "uuid": "^9.0.1"
+          }
+        },
+        "@smithy/middleware-serde": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+          "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-stack": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+          "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+          "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+          "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+          "requires": {
+            "@smithy/abort-controller": "^3.1.1",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+          "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+          "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+          "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/service-error-classification": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/smithy-client": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+          "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+          "requires": {
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-stack": "^3.0.3",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-stream": "^3.1.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+          "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+          "requires": {
+            "@smithy/querystring-parser": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-base64": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+          "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+          "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-node": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+          "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+          "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-config-provider": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+          "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-browser": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+          "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-node": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+          "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
+          "requires": {
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/credential-provider-imds": "^3.2.0",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-hex-encoding": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+          "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-middleware": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+          "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-retry": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+          "requires": {
+            "@smithy/service-error-classification": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-stream": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+          "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+          "requires": {
+            "@smithy/fetch-http-handler": "^3.2.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+          "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+          "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+        }
       }
     },
     "@aws-sdk/client-rds": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-rds/-/client-rds-3.231.0.tgz",
-      "integrity": "sha512-5FqCEbP8Yn5YHMXIFl3WUsalhM4yuaptvHYm8HAEzCEgqhLXZfBWIQACkkfd333C2b9Wu4OrwYAF8k+fB5nwvQ==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-rds/-/client-rds-3.645.0.tgz",
+      "integrity": "sha512-UQU9Kj7HZlBypn0+vYvu76/pKzZZqmRQAKNXgV7cPJ+Rx2o2I9hgCUCGVEg5/0UoU85RRqekQS3tYr+GTfnNKA==",
       "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.231.0",
-        "@aws-sdk/config-resolver": "3.231.0",
-        "@aws-sdk/credential-provider-node": "3.231.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.229.0",
-        "@aws-sdk/middleware-sdk-rds": "3.226.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.226.0",
-        "@aws-sdk/util-defaults-mode-node": "3.231.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.226.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.645.0",
+        "@aws-sdk/client-sts": "3.645.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/credential-provider-node": "3.645.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-sdk-rds": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.645.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.645.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.2",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+          "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/config-resolver": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+          "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-config-provider": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/credential-provider-imds": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+          "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+          "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/hash-node": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+          "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/invalid-dependency": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+          "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+          "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-content-length": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+          "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-endpoint": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+          "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+          "requires": {
+            "@smithy/middleware-serde": "^3.0.3",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-retry": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+          "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/service-error-classification": "^3.0.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-retry": "^3.0.3",
+            "tslib": "^2.6.2",
+            "uuid": "^9.0.1"
+          }
+        },
+        "@smithy/middleware-serde": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+          "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-stack": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+          "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+          "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+          "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+          "requires": {
+            "@smithy/abort-controller": "^3.1.1",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+          "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+          "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+          "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/service-error-classification": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/smithy-client": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+          "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+          "requires": {
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-stack": "^3.0.3",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-stream": "^3.1.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+          "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+          "requires": {
+            "@smithy/querystring-parser": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-base64": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+          "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+          "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-node": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+          "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+          "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-config-provider": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+          "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-browser": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+          "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-node": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+          "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
+          "requires": {
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/credential-provider-imds": "^3.2.0",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-hex-encoding": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+          "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-middleware": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+          "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-retry": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+          "requires": {
+            "@smithy/service-error-classification": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-stream": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+          "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+          "requires": {
+            "@smithy/fetch-http-handler": "^3.2.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+          "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+          "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+        }
       }
     },
     "@aws-sdk/client-ssm": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.231.0.tgz",
-      "integrity": "sha512-NiXoWdIOxhEALLEbA6L4CqsYLRBOVlz/yPU5gsOJlO2U0zlafBwGZX7bE1S3ANnGkaOAHwQWVAAwKTqtheJy7g==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.645.0.tgz",
+      "integrity": "sha512-S1SKgvIsr4oaPK+2OiDoqxihiTlNqQytTfuUgzx8evxhgpIjdxwHZ/1GCdEQtR5X88ZU1y4ryVMyCvFVjwZjsQ==",
       "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.231.0",
-        "@aws-sdk/config-resolver": "3.231.0",
-        "@aws-sdk/credential-provider-node": "3.231.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.229.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.226.0",
-        "@aws-sdk/util-defaults-mode-node": "3.231.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.226.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.645.0",
+        "@aws-sdk/client-sts": "3.645.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/credential-provider-node": "3.645.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.645.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.645.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.2",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+          "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/config-resolver": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+          "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-config-provider": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/credential-provider-imds": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+          "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+          "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/hash-node": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+          "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/invalid-dependency": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+          "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+          "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-content-length": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+          "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-endpoint": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+          "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+          "requires": {
+            "@smithy/middleware-serde": "^3.0.3",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-retry": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+          "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/service-error-classification": "^3.0.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-retry": "^3.0.3",
+            "tslib": "^2.6.2",
+            "uuid": "^9.0.1"
+          }
+        },
+        "@smithy/middleware-serde": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+          "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-stack": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+          "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+          "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+          "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+          "requires": {
+            "@smithy/abort-controller": "^3.1.1",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+          "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+          "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+          "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/service-error-classification": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/smithy-client": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+          "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+          "requires": {
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-stack": "^3.0.3",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-stream": "^3.1.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+          "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+          "requires": {
+            "@smithy/querystring-parser": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-base64": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+          "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+          "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-node": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+          "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+          "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-config-provider": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+          "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-browser": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+          "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-node": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+          "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
+          "requires": {
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/credential-provider-imds": "^3.2.0",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-hex-encoding": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+          "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-middleware": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+          "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-retry": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+          "requires": {
+            "@smithy/service-error-classification": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-stream": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+          "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+          "requires": {
+            "@smithy/fetch-http-handler": "^3.2.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+          "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+          "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+        }
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.231.0.tgz",
-      "integrity": "sha512-/q7BptaMiT6/wxW9vE/gcQuApMXio5vdTuqt77A6+mjqhNzYFfCn7RRS4BU8KEOpZObnYBKP3mYe3NDccEbMzQ==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.645.0.tgz",
+      "integrity": "sha512-2rc8TjnsNddOeKQ/pfNN7deNvGLXAeKeYtHtGDAiM2qfTKxd2sNcAsZ+JCDLyshuD4xLM5fpUyR0X8As9EAouQ==",
       "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.231.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.229.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.226.0",
-        "@aws-sdk/util-defaults-mode-node": "3.231.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.645.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.645.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+          "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/config-resolver": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+          "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-config-provider": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/credential-provider-imds": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+          "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+          "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/hash-node": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+          "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/invalid-dependency": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+          "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+          "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-content-length": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+          "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-endpoint": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+          "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+          "requires": {
+            "@smithy/middleware-serde": "^3.0.3",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-retry": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+          "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/service-error-classification": "^3.0.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-retry": "^3.0.3",
+            "tslib": "^2.6.2",
+            "uuid": "^9.0.1"
+          }
+        },
+        "@smithy/middleware-serde": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+          "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-stack": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+          "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+          "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+          "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+          "requires": {
+            "@smithy/abort-controller": "^3.1.1",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+          "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+          "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+          "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/service-error-classification": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/smithy-client": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+          "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+          "requires": {
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-stack": "^3.0.3",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-stream": "^3.1.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+          "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+          "requires": {
+            "@smithy/querystring-parser": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-base64": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+          "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+          "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-node": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+          "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+          "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-config-provider": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+          "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-browser": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+          "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-node": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+          "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
+          "requires": {
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/credential-provider-imds": "^3.2.0",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-hex-encoding": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+          "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-middleware": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+          "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-retry": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+          "requires": {
+            "@smithy/service-error-classification": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-stream": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+          "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+          "requires": {
+            "@smithy/fetch-http-handler": "^3.2.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+          "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+          "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+        }
       }
     },
     "@aws-sdk/client-sso-oidc": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.231.0.tgz",
-      "integrity": "sha512-yqEZW9/Q6VvMDMcQoE52oa/oa6F8z8cqyax7m29VpuVrncYcfELpkZKWPoaJVfierR5ysKfKiAU0acPgMpvllQ==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.645.0.tgz",
+      "integrity": "sha512-X9ULtdk3cO+1ysurEkJ1MSnu6U00qodXx+IVual+1jXX4RYY1WmQmfo7uDKf6FFkz7wW1DAqU+GJIBNQr0YH8A==",
       "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.231.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.229.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.226.0",
-        "@aws-sdk/util-defaults-mode-node": "3.231.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/credential-provider-node": "3.645.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.645.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.645.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+          "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/config-resolver": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+          "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-config-provider": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/credential-provider-imds": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+          "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+          "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/hash-node": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+          "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/invalid-dependency": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+          "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+          "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-content-length": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+          "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-endpoint": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+          "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+          "requires": {
+            "@smithy/middleware-serde": "^3.0.3",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-retry": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+          "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/service-error-classification": "^3.0.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-retry": "^3.0.3",
+            "tslib": "^2.6.2",
+            "uuid": "^9.0.1"
+          }
+        },
+        "@smithy/middleware-serde": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+          "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-stack": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+          "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+          "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+          "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+          "requires": {
+            "@smithy/abort-controller": "^3.1.1",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+          "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+          "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+          "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/service-error-classification": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/smithy-client": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+          "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+          "requires": {
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-stack": "^3.0.3",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-stream": "^3.1.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+          "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+          "requires": {
+            "@smithy/querystring-parser": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-base64": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+          "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+          "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-node": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+          "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+          "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-config-provider": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+          "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-browser": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+          "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-node": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+          "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
+          "requires": {
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/credential-provider-imds": "^3.2.0",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-hex-encoding": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+          "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-middleware": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+          "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-retry": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+          "requires": {
+            "@smithy/service-error-classification": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-stream": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+          "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+          "requires": {
+            "@smithy/fetch-http-handler": "^3.2.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+          "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+          "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+        }
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.231.0.tgz",
-      "integrity": "sha512-5WYqlcbM49ofOFBsu28QBt3t26M5D9XynhSaswSrCzawwdNkIMYQrKOCplF5mqOy+GywVIRrFeCVVrAKPMZJxQ==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.645.0.tgz",
+      "integrity": "sha512-6azXYtvtnAsPf2ShN9vKynIYVcJOpo6IoVmoMAVgNaBJyllP+s/RORzranYZzckqfmrudSxtct4rVapjLWuAMg==",
       "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.231.0",
-        "@aws-sdk/credential-provider-node": "3.231.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.229.0",
-        "@aws-sdk/middleware-sdk-sts": "3.226.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.226.0",
-        "@aws-sdk/util-defaults-mode-node": "3.231.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.645.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/credential-provider-node": "3.645.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.645.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.645.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+          "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/config-resolver": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+          "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-config-provider": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/credential-provider-imds": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+          "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+          "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/hash-node": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+          "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/invalid-dependency": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+          "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+          "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-content-length": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+          "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-endpoint": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+          "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+          "requires": {
+            "@smithy/middleware-serde": "^3.0.3",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-retry": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+          "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/service-error-classification": "^3.0.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-retry": "^3.0.3",
+            "tslib": "^2.6.2",
+            "uuid": "^9.0.1"
+          }
+        },
+        "@smithy/middleware-serde": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+          "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-stack": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+          "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+          "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+          "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+          "requires": {
+            "@smithy/abort-controller": "^3.1.1",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+          "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+          "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+          "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/service-error-classification": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/smithy-client": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+          "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+          "requires": {
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-stack": "^3.0.3",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-stream": "^3.1.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+          "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+          "requires": {
+            "@smithy/querystring-parser": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-base64": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+          "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+          "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-node": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+          "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+          "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-config-provider": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+          "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-browser": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+          "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-defaults-mode-node": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+          "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
+          "requires": {
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/credential-provider-imds": "^3.2.0",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-hex-encoding": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+          "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-middleware": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+          "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-retry": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+          "requires": {
+            "@smithy/service-error-classification": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-stream": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+          "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+          "requires": {
+            "@smithy/fetch-http-handler": "^3.2.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+          "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+          "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+        }
       }
     },
-    "@aws-sdk/config-resolver": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.231.0.tgz",
-      "integrity": "sha512-qpjV4Fw/NQ4a0p5/qwzqaShflYRlY/SPcgA7N5GTJjIjZjg3NV+5BKJSF3VeZcNKfbXq68kkn207OSCpyheYxQ==",
+    "@aws-sdk/core": {
+      "version": "3.635.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.635.0.tgz",
+      "integrity": "sha512-i1x/E/sgA+liUE1XJ7rj1dhyXpAKO1UKFUcTTHXok2ARjWTvszHnSXMOsB77aPbmn0fUp1JTx2kHUAZ1LVt5Bg==",
       "requires": {
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "tslib": "^2.3.1"
+        "@smithy/core": "^2.4.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+          "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+          "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+          "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-endpoint": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+          "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+          "requires": {
+            "@smithy/middleware-serde": "^3.0.3",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-serde": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+          "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-stack": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+          "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+          "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+          "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+          "requires": {
+            "@smithy/abort-controller": "^3.1.1",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+          "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+          "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+          "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/signature-v4": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+          "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/smithy-client": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+          "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+          "requires": {
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-stack": "^3.0.3",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-stream": "^3.1.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+          "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+          "requires": {
+            "@smithy/querystring-parser": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-base64": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+          "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+          "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-hex-encoding": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+          "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-middleware": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+          "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-stream": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+          "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+          "requires": {
+            "@smithy/fetch-http-handler": "^3.2.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+          "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+          "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/credential-provider-cognito-identity": {
@@ -25065,91 +33011,569 @@
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
-      "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
-    "@aws-sdk/credential-provider-imds": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
-      "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+    "@aws-sdk/credential-provider-http": {
+      "version": "3.635.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.635.0.tgz",
+      "integrity": "sha512-iJyRgEjOCQlBMXqtwPLIKYc7Bsc6nqjrZybdMDenPDa+kmLg7xh8LxHsu9088e+2/wtLicE34FsJJIfzu3L82g==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+          "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+          "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+          "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-endpoint": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+          "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+          "requires": {
+            "@smithy/middleware-serde": "^3.0.3",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-serde": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+          "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-stack": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+          "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+          "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+          "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+          "requires": {
+            "@smithy/abort-controller": "^3.1.1",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+          "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+          "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+          "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/smithy-client": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+          "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+          "requires": {
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-stack": "^3.0.3",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-stream": "^3.1.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+          "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+          "requires": {
+            "@smithy/querystring-parser": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-base64": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+          "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+          "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-hex-encoding": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+          "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-middleware": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+          "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-stream": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+          "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+          "requires": {
+            "@smithy/fetch-http-handler": "^3.2.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+          "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+          "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.231.0.tgz",
-      "integrity": "sha512-4JJgrJg2O91Vki4m5nSQNZGX/5yAYgzG1IOjeZ+8vCDxfR+jA2O9+/Xhi2/8aDpb1da77OJ+cK1+ezzSMchIfQ==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.645.0.tgz",
+      "integrity": "sha512-LlZW0qwUwNlTaAIDCNpLbPsyXvS42pRIwF92fgtCQedmdnpN3XRUC6hcwSYI7Xru3GGKp3RnceOvsdOaRJORsw==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.226.0",
-        "@aws-sdk/credential-provider-imds": "3.226.0",
-        "@aws-sdk/credential-provider-sso": "3.231.0",
-        "@aws-sdk/credential-provider-web-identity": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.635.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.645.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/credential-provider-imds": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+          "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+          "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+          "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+          "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+          "requires": {
+            "@smithy/querystring-parser": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.231.0.tgz",
-      "integrity": "sha512-DOojjyYdLNeBQv9+PaDXmvvww9SmcZsaL1YCl27e5larcJSMfT41vn4WRnVRu2zBI2BIi464Z8ziRRKwd2YFVg==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.645.0.tgz",
+      "integrity": "sha512-eGFFuNvLeXjCJf5OCIuSEflxUowmK+bCS+lK4M8ofsYOEGAivdx7C0UPxNjHpvM8wKd8vpMl5phTeS9BWX5jMQ==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.226.0",
-        "@aws-sdk/credential-provider-imds": "3.226.0",
-        "@aws-sdk/credential-provider-ini": "3.231.0",
-        "@aws-sdk/credential-provider-process": "3.226.0",
-        "@aws-sdk/credential-provider-sso": "3.231.0",
-        "@aws-sdk/credential-provider-web-identity": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.635.0",
+        "@aws-sdk/credential-provider-ini": "3.645.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.645.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/credential-provider-imds": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+          "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+          "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+          "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+          "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+          "requires": {
+            "@smithy/querystring-parser": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
-      "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.231.0.tgz",
-      "integrity": "sha512-aImUD+PAqZ7A2C1ef7gskMN3KuxFT4Am1Vrl6M0oLGyrhKG2QtRT/UaXJE+Yt6d/C2qc2OsQ9j2oim7D6Qha/A==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.645.0.tgz",
+      "integrity": "sha512-d6XuChAl5NCsCrUexc6AFb4efPmb9+66iwPylKG+iMTMYgO1ackfy1Q2/f35jdn0jolkPkzKsVyfzsEVoID6ew==",
       "requires": {
-        "@aws-sdk/client-sso": "3.231.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/token-providers": "3.231.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso": "3.645.0",
+        "@aws-sdk/token-providers": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
-      "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+      "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
       "requires": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/credential-providers": {
@@ -25619,409 +34043,734 @@
         }
       }
     },
-    "@aws-sdk/fetch-http-handler": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
-      "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/querystring-builder": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/hash-node": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
-      "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
-      "requires": {
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/invalid-dependency": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
-      "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
-      "requires": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-content-length": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
-      "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-endpoint": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
-      "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
-      "requires": {
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "tslib": "^2.3.1"
-      }
-    },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
-      "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/protocol-http": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+          "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
-      "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
       "requires": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
-      "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-retry": {
-      "version": "3.229.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.229.0.tgz",
-      "integrity": "sha512-/y0BWio9b2RRH2QvRTohbuqE0vhH4IZKlc6k+JRbGV9aSwyOzACU/L/qkGftC/W0puvgNvZYjGxmB6cGHAEZaw==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/service-error-classification": "3.229.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/protocol-http": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+          "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/middleware-sdk-ec2": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.226.0.tgz",
-      "integrity": "sha512-1ZXmNO5Gs/7p2KA8HYcIgcehEvzo7l4y2wtwIEOdkeT9rARwNm3IfjphrhzEY9Rl4GVbgEVaLr+RldngC8vDKw==",
+      "version": "3.635.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.635.0.tgz",
+      "integrity": "sha512-XsHvRUOqTyIV9M9uKMBS/8Hd5pW8RNTo3vlouQy1RDON8/LynevZ+RN5bo22iKrtOPM4J5j0YAcntUopWb1ljg==",
       "requires": {
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-format-url": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-format-url": "3.609.0",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+          "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+          "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+          "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-endpoint": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+          "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+          "requires": {
+            "@smithy/middleware-serde": "^3.0.3",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-serde": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+          "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-stack": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+          "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+          "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+          "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+          "requires": {
+            "@smithy/abort-controller": "^3.1.1",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+          "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+          "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+          "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/signature-v4": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+          "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/smithy-client": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+          "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+          "requires": {
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-stack": "^3.0.3",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-stream": "^3.1.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+          "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+          "requires": {
+            "@smithy/querystring-parser": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-base64": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+          "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+          "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-hex-encoding": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+          "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-middleware": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+          "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-stream": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+          "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+          "requires": {
+            "@smithy/fetch-http-handler": "^3.2.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+          "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+          "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/middleware-sdk-rds": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-rds/-/middleware-sdk-rds-3.226.0.tgz",
-      "integrity": "sha512-ETBZPJnkjAhRuoIPI6Ku1dGsyW3gHNj95TuZb8pT//e6HySOpBxlG1SSBwnpfKuZYUSE5q+hjzK/rDNzcpzbUQ==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-rds/-/middleware-sdk-rds-3.620.0.tgz",
+      "integrity": "sha512-pokuq3rMJfn8ZNUIhAKn0c1nQtvClPLzh5h1fOXAeRXmNjp+YPXQ4CIsGRcqDNO8lkUyyfV42WnPCdUZmR9zAA==",
       "requires": {
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-format-url": "3.226.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
-      "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
-      "requires": {
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-serde": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
-      "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
-      "requires": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-signing": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
-      "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-stack": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
-      "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
-      "requires": {
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-format-url": "3.609.0",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/is-array-buffer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+          "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-endpoint": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+          "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+          "requires": {
+            "@smithy/middleware-serde": "^3.0.3",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-serde": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+          "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+          "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+          "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+          "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/signature-v4": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+          "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+          "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+          "requires": {
+            "@smithy/querystring-parser": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+          "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-hex-encoding": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+          "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-middleware": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+          "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+          "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+          "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
-      "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.645.0.tgz",
+      "integrity": "sha512-NpTAtqWK+49lRuxfz7st9for80r4NriCMK0RfdJSoPFVntjsSQiQ7+2nW2XL05uVY633e9DvCAw8YatX3zd1mw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.645.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/protocol-http": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+          "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
-    "@aws-sdk/node-config-provider": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
-      "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+    "@aws-sdk/region-config-resolver": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
       "requires": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/node-http-handler": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
-      "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
-      "requires": {
-        "@aws-sdk/abort-controller": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/querystring-builder": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/property-provider": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
-      "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
-      "requires": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/protocol-http": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
-      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
-      "requires": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/querystring-builder": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
-      "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
-      "requires": {
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/querystring-parser": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
-      "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
-      "requires": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/service-error-classification": {
-      "version": "3.229.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
-      "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg=="
-    },
-    "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
-      "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
-      "requires": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/signature-v4": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
-      "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/smithy-client": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.226.0.tgz",
-      "integrity": "sha512-BWr1FhWSUhkSBp0TLzliD5AQBjA2Jmo9FlOOt+cBwd9BKkSGlGj+HgATYJ83Sjjg2+J6qvEZBxB78LKVHhorBw==",
-      "requires": {
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/node-config-provider": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+          "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-config-provider": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+          "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-middleware": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+          "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.231.0.tgz",
-      "integrity": "sha512-sxx6X/moSdukyrnoBtLxmgQQLWqixMc/qAM5yNg5lfNoGamWslH6CnT1HlxTFv71q8/1xwnvZ4LC2kbD6vDc6Q==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.231.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/types": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
-      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
       "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/url-parser": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
-      "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
-      "requires": {
-        "@aws-sdk/querystring-parser": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-base64": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
-      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-body-length-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-body-length-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.226.0.tgz",
-      "integrity": "sha512-chLx+6AeMSjuPsCVbI1B4Pg3jftjjcsuTsJucjo0DKBb1VSWqPCitmOILQVvKiA2Km8TSs3VcbUuOCyDExkzAg==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.231.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.231.0.tgz",
-      "integrity": "sha512-jH+9z96x8Oxv+bqBdD7x8CRvbKzM9id+VHzI9+h1oTY9J+6MkUubPshliBTQeus5pD03NBOS/2F3GX2rJ9Avuw==",
-      "requires": {
-        "@aws-sdk/config-resolver": "3.231.0",
-        "@aws-sdk/credential-provider-imds": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
-      "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+      "version": "3.645.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.645.0.tgz",
+      "integrity": "sha512-Oe+xaU4ic4PB1k3pb5VTC1/MWES13IlgpaQw01bVHGfwP6Yv6zZOxizRzca2Y3E+AyR+nKD7vXtHRY+w3bi4bg==",
       "requires": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-endpoints": "^2.0.5",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/util-format-url": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.226.0.tgz",
-      "integrity": "sha512-IhuA8iuJL1urWqZZmVzW79mHnwFEEP6rMsSKgAfMmuzowhtgk9p/sT2OVPkXk0LeZL2Ghsnw1W2JfPIs8x1qVg==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.609.0.tgz",
+      "integrity": "sha512-fuk29BI/oLQlJ7pfm6iJ4gkEpHdavffAALZwXh9eaY1vQ0ip0aKfRTiNudPoJjyyahnz5yJ1HkmlcDitlzsOrQ==",
       "requires": {
-        "@aws-sdk/querystring-builder": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-      "requires": {
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/querystring-builder": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+          "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+          "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/util-locate-window": {
@@ -26032,75 +34781,83 @@
         "tslib": "^2.3.1"
       }
     },
-    "@aws-sdk/util-middleware": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
-      "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-retry": {
-      "version": "3.229.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
-      "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
-      "requires": {
-        "@aws-sdk/service-error-classification": "3.229.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
-      "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
       "requires": {
-        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
-      "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/node-config-provider": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+          "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@aws-sdk/util-utf8-browser": {
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
       "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "dev": true,
       "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-utf8-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-waiter": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
-      "integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
-      "requires": {
-        "@aws-sdk/abort-controller": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
@@ -28744,6 +37501,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.5.tgz",
       "integrity": "sha512-byVZ2KWLMPYAZGKjRpniAzLcygJO4ruClZKdJTuB0eCB76ONFTdptBHlviHpAZXknRz7skYWPfcgO9v30A1SyA==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
@@ -28753,6 +37511,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.5.tgz",
       "integrity": "sha512-n0c2AXz+kjALY2FQr7Zy9zhYigXzboIh1AuUUVCqFBKFtdEvTwnwPXrTDoEehLiRTUHNL+4yzZ3s+D0kKYSLSg==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.2.2",
         "@smithy/util-config-provider": "^2.0.0",
@@ -28760,10 +37519,306 @@
         "tslib": "^2.5.0"
       }
     },
+    "@smithy/core": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.0.tgz",
+      "integrity": "sha512-cHXq+FneIF/KJbt4q4pjN186+Jf4ZB0ZOqEaZMBhT79srEyGDDBV31NqBRBjazz8ppQ1bJbDJMY9ba5wKFV36w==",
+      "requires": {
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+          "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/fetch-http-handler": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+          "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/is-array-buffer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+          "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-endpoint": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+          "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+          "requires": {
+            "@smithy/middleware-serde": "^3.0.3",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/url-parser": "^3.0.3",
+            "@smithy/util-middleware": "^3.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-retry": {
+          "version": "3.0.15",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+          "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+          "requires": {
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/service-error-classification": "^3.0.3",
+            "@smithy/smithy-client": "^3.2.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-retry": "^3.0.3",
+            "tslib": "^2.6.2",
+            "uuid": "^9.0.1"
+          }
+        },
+        "@smithy/middleware-serde": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+          "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/middleware-stack": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+          "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-config-provider": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+          "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+          "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+          "requires": {
+            "@smithy/abort-controller": "^3.1.1",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/querystring-builder": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+          "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+          "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/querystring-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+          "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/service-error-classification": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/smithy-client": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+          "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+          "requires": {
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-stack": "^3.0.3",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-stream": "^3.1.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/url-parser": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+          "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+          "requires": {
+            "@smithy/querystring-parser": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-base64": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+          "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-body-length-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+          "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+          "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-hex-encoding": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+          "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-middleware": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+          "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-retry": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+          "requires": {
+            "@smithy/service-error-classification": "^3.0.3",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-stream": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+          "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+          "requires": {
+            "@smithy/fetch-http-handler": "^3.2.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-base64": "^3.0.0",
+            "@smithy/util-buffer-from": "^3.0.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+          "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+          "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+          "requires": {
+            "@smithy/util-buffer-from": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+        }
+      }
+    },
     "@smithy/credential-provider-imds": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.5.tgz",
       "integrity": "sha512-KFcf/e0meFkQNyteJ65f1G19sgUEY1e5zL7hyAEUPz2SEfBmC9B37WyRq87G3MEEsvmAWwCRu7nFFYUKtR3svQ==",
+      "dev": true,
       "requires": {
         "@smithy/node-config-provider": "^2.0.5",
         "@smithy/property-provider": "^2.0.5",
@@ -28776,6 +37831,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.3.tgz",
       "integrity": "sha512-3l/uKZBsV/6uMe2qXvh1C8ut/w6JHKgy7ic7N2QPR1SSuNWKNQBX0iVBqJpPtQz0UDeQYM4cNmwDBX+hw74EEw==",
+      "dev": true,
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
         "@smithy/types": "^2.2.0",
@@ -28787,6 +37843,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.5.tgz",
       "integrity": "sha512-EzFoMowdBNy1VqtvkiXgPFEdosIAt4/4bgZ8uiDiUyfhmNXq/3bV+CagPFFBsgFOR/X2XK4zFZHRsoa7PNHVVg==",
+      "dev": true,
       "requires": {
         "@smithy/protocol-http": "^2.0.5",
         "@smithy/querystring-builder": "^2.0.5",
@@ -28799,6 +37856,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.5.tgz",
       "integrity": "sha512-mk551hIywBITT+kXruRNXk7f8Fy7DTzBjZJSr/V6nolYKmUHIG3w5QU6nO9qPYEQGKc/yEPtkpdS28ndeG93lA==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.2.2",
         "@smithy/util-buffer-from": "^2.0.0",
@@ -28810,6 +37868,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.5.tgz",
       "integrity": "sha512-0wEi+JT0hM+UUwrJVYbqjuGFhy5agY/zXyiN7BNAJ1XoCDjU5uaNSj8ekPWsXd/d4yM6NSe8UbPd8cOc1+3oBQ==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
@@ -28827,6 +37886,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.5.tgz",
       "integrity": "sha512-E7VwV5H02fgZIUGRli4GevBCAPvkyEI/fgl9SU47nPPi3DAAX3nEtUb8xfGbXjOcJ5BdSUoWWZn42tEd/blOqA==",
+      "dev": true,
       "requires": {
         "@smithy/protocol-http": "^2.0.5",
         "@smithy/types": "^2.2.2",
@@ -28837,6 +37897,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.5.tgz",
       "integrity": "sha512-tyzDuoNTbsMQCq5Xkc4QOt6e2GACUllQIV8SQ5fc59FtOIV9/vbf58/GxVjZm2o8+MMbdDBANjTDZe/ijZKfyA==",
+      "dev": true,
       "requires": {
         "@smithy/middleware-serde": "^2.0.5",
         "@smithy/types": "^2.2.2",
@@ -28849,6 +37910,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.5.tgz",
       "integrity": "sha512-ulIfbFyzQTVnJbLjUl1CTSi0etg6tej/ekwaLp0Gn8ybUkDkKYa+uB6CF/m2J5B6meRwyJlsryR+DjaOVyiicg==",
+      "dev": true,
       "requires": {
         "@smithy/protocol-http": "^2.0.5",
         "@smithy/service-error-classification": "^2.0.0",
@@ -28863,6 +37925,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.5.tgz",
       "integrity": "sha512-in0AA5sous74dOfTGU9rMJBXJ0bDVNxwdXtEt5lh3FVd2sEyjhI+rqpLLRF1E4ixbw3RSEf80hfRpcPdjg4vvQ==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
@@ -28872,6 +37935,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.0.tgz",
       "integrity": "sha512-31XC1xNF65nlbc16yuh3wwTudmqs6qy4EseQUGF8A/p2m/5wdd/cnXJqpniy/XvXVwkHPz/GwV36HqzHtIKATQ==",
+      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -28880,6 +37944,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.5.tgz",
       "integrity": "sha512-LRtjV9WkhONe2lVy+ipB/l1GX60ybzBmFyeRUoLUXWKdnZ3o81jsnbKzMK8hKq8eFSWPk+Lmyx6ZzCQabGeLxg==",
+      "dev": true,
       "requires": {
         "@smithy/property-provider": "^2.0.5",
         "@smithy/shared-ini-file-loader": "^2.0.5",
@@ -28891,6 +37956,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.5.tgz",
       "integrity": "sha512-lZm5DZf4b3V0saUw9WTC4/du887P6cy2fUyQgQQKRRV6OseButyD5yTzeMmXE53CaXJBMBsUvvIQ0hRVxIq56w==",
+      "dev": true,
       "requires": {
         "@smithy/abort-controller": "^2.0.5",
         "@smithy/protocol-http": "^2.0.5",
@@ -28903,6 +37969,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.5.tgz",
       "integrity": "sha512-cAFSUhX6aiHcmpWfrCLKvwBtgN1F6A0N8qY/8yeSi0LRLmhGqsY1/YTxFE185MCVzYbqBGXVr9TBv4RUcIV4rA==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
@@ -28912,6 +37979,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.5.tgz",
       "integrity": "sha512-d2hhHj34mA2V86doiDfrsy2fNTnUOowGaf9hKb0hIPHqvcnShU4/OSc4Uf1FwHkAdYF3cFXTrj5VGUYbEuvMdw==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
@@ -28921,6 +37989,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.5.tgz",
       "integrity": "sha512-4DCX9krxLzATj+HdFPC3i8pb7XTAWzzKqSw8aTZMjXjtQY+vhe4azMAqIvbb6g7JKwIkmkRAjK6EXO3YWSnJVQ==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.2.2",
         "@smithy/util-uri-escape": "^2.0.0",
@@ -28931,6 +38000,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.5.tgz",
       "integrity": "sha512-C2stCULH0r54KBksv3AWcN8CLS3u9+WsEW8nBrvctrJ5rQTNa1waHkffpVaiKvcW2nP0aIMBPCobD/kYf/q9mA==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
@@ -28939,12 +38009,14 @@
     "@smithy/service-error-classification": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.0.tgz",
-      "integrity": "sha512-2z5Nafy1O0cTf69wKyNjGW/sNVMiqDnb4jgwfMG8ye8KnFJ5qmJpDccwIbJNhXIfbsxTg9SEec2oe1cexhMJvw=="
+      "integrity": "sha512-2z5Nafy1O0cTf69wKyNjGW/sNVMiqDnb4jgwfMG8ye8KnFJ5qmJpDccwIbJNhXIfbsxTg9SEec2oe1cexhMJvw==",
+      "dev": true
     },
     "@smithy/shared-ini-file-loader": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.5.tgz",
       "integrity": "sha512-Mvtk6FwMtfbKRC4YuSsIqRYp9WTxsSUJVVo2djgyhcacKGMqicHDWSAmgy3sDrKv+G/G6xTZCPwm6pJARtdxVg==",
+      "dev": true,
       "requires": {
         "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
@@ -28954,6 +38026,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.3.tgz",
       "integrity": "sha512-AZ+951EAcNqas2RTq4xQvuX4uZqPV/zCcbs7ACqpuxcjYAFU2FKRPpQHqsDN0jbJwI3Scw75xhSKcGWFf2/Olg==",
+      "dev": true,
       "requires": {
         "@smithy/eventstream-codec": "^2.0.3",
         "@smithy/is-array-buffer": "^2.0.0",
@@ -28969,6 +38042,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.5.tgz",
       "integrity": "sha512-kCTFr8wfOAWKDzGvfBElc6shHigWtHNhMQ1IbosjC4jOlayFyZMSs2PysKB+Ox/dhQ41KqOzgVjgiQ+PyWqHMQ==",
+      "dev": true,
       "requires": {
         "@smithy/middleware-stack": "^2.0.0",
         "@smithy/types": "^2.2.2",
@@ -28980,6 +38054,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.2.tgz",
       "integrity": "sha512-4PS0y1VxDnELGHGgBWlDksB2LJK8TG8lcvlWxIsgR+8vROI7Ms8h1P4FQUx+ftAX2QZv5g1CJCdhdRmQKyonyw==",
+      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -28988,6 +38063,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.5.tgz",
       "integrity": "sha512-OdMBvZhpckQSkugCXNJQCvqJ71wE7Ftxce92UOQLQ9pwF6hoS5PLL7wEfpnuEXtStzBqJYkzu1C1ZfjuFGOXAA==",
+      "dev": true,
       "requires": {
         "@smithy/querystring-parser": "^2.0.5",
         "@smithy/types": "^2.2.2",
@@ -28998,6 +38074,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
       "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
+      "dev": true,
       "requires": {
         "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
@@ -29007,6 +38084,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
       "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -29015,6 +38093,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
       "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -29032,6 +38111,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
       "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -29040,6 +38120,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.5.tgz",
       "integrity": "sha512-yciP6TPttLsj731aHTvekgyuCGXQrEAJibEwEWAh3kzaDsfGAVCuZSBlyvC2Dl3TZmHKCOQwHV8mIE7KQCTPuQ==",
+      "dev": true,
       "requires": {
         "@smithy/property-provider": "^2.0.5",
         "@smithy/types": "^2.2.2",
@@ -29051,6 +38132,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.5.tgz",
       "integrity": "sha512-M07t99rWasXt+IaDZDyP3BkcoEm/mgIE1RIMASrE49LKSNxaVN7PVcgGc77+4uu2kzBAyqJKy79pgtezuknyjQ==",
+      "dev": true,
       "requires": {
         "@smithy/config-resolver": "^2.0.5",
         "@smithy/credential-provider-imds": "^2.0.5",
@@ -29060,10 +38142,60 @@
         "tslib": "^2.5.0"
       }
     },
+    "@smithy/util-endpoints": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.5.tgz",
+      "integrity": "sha512-ReQP0BWihIE68OAblC/WQmDD40Gx+QY1Ez8mTdFMXpmjfxSyz2fVQu3A4zXRfQU9sZXtewk3GmhfOHswvX+eNg==",
+      "requires": {
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/node-config-provider": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+          "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+          "requires": {
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/property-provider": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/shared-ini-file-loader": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        }
+      }
+    },
     "@smithy/util-hex-encoding": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
       "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -29072,6 +38204,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.0.tgz",
       "integrity": "sha512-eCWX4ECuDHn1wuyyDdGdUWnT4OGyIzV0LN1xRttBFMPI9Ff/4heSHVxneyiMtOB//zpXWCha1/SWHJOZstG7kA==",
+      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -29080,6 +38213,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.0.tgz",
       "integrity": "sha512-/dvJ8afrElasuiiIttRJeoS2sy8YXpksQwiM/TcepqdRVp7u4ejd9C4IQURHNjlfPUT7Y6lCDSa2zQJbdHhVTg==",
+      "dev": true,
       "requires": {
         "@smithy/service-error-classification": "^2.0.0",
         "tslib": "^2.5.0"
@@ -29089,6 +38223,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.5.tgz",
       "integrity": "sha512-ylx27GwI05xLpYQ4hDIfS15vm+wYjNN0Sc2P0FxuzgRe8v0BOLHppGIQ+Bezcynk8C9nUzsUue3TmtRhjut43g==",
+      "dev": true,
       "requires": {
         "@smithy/fetch-http-handler": "^2.0.5",
         "@smithy/node-http-handler": "^2.0.5",
@@ -29104,6 +38239,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
       "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -29118,13 +38254,32 @@
       }
     },
     "@smithy/util-waiter": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.5.tgz",
-      "integrity": "sha512-1lkkUmI/bhaDX+LIT3RiUNAn+NzPmsWjE7beMq0oQ3H1/CffaILIN67riDA0aE1YBj6xll7uWMIy4tJqc+peXw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.2.tgz",
+      "integrity": "sha512-4pP0EV3iTsexDx+8PPGAKCQpd/6hsQBaQhqWzU4hqKPHN5epPsxKbvUTIiYIHTxaKt6/kEaqPBpu/ufvfbrRzw==",
       "requires": {
-        "@smithy/abort-controller": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "tslib": "^2.5.0"
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+          "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+          "requires": {
+            "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/types": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        }
       }
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
@@ -30683,11 +39838,11 @@
     "basti": {
       "version": "file:packages/basti",
       "requires": {
-        "@aws-sdk/client-ec2": "3.231.0",
-        "@aws-sdk/client-elasticache": "3.398.0",
-        "@aws-sdk/client-iam": "3.231.0",
-        "@aws-sdk/client-rds": "3.231.0",
-        "@aws-sdk/client-ssm": "3.231.0",
+        "@aws-sdk/client-ec2": "3.645.0",
+        "@aws-sdk/client-elasticache": "3.645.0",
+        "@aws-sdk/client-iam": "3.645.0",
+        "@aws-sdk/client-rds": "3.645.0",
+        "@aws-sdk/client-ssm": "3.645.0",
         "@types/inquirer": "8.2.1",
         "@types/yargs": "17.0.10",
         "basti-session-manager-binary-darwin-arm64": "1.2.295.0",
@@ -30701,7 +39856,7 @@
         "ora": "6.1.2",
         "ts-node": "10.9.1",
         "yargs": "17.7.2",
-        "zod": "3.18.0",
+        "zod": "3.23.8",
         "zod-validation-error": "1.3.0"
       }
     },
@@ -32953,9 +42108,9 @@
       }
     },
     "fast-xml-parser": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
       "requires": {
         "strnum": "^1.0.5"
       }
@@ -35334,16 +44489,6 @@
         "yargs": "^17"
       },
       "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.387.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.387.0.tgz",
-          "integrity": "sha512-YTjFabNwjTF+6yl88f0/tWff018qmmgMmjlw45s6sdVKueWxdxV68U7gepNLF2nhaQPZa6FDOBoA51NaviVs0Q==",
-          "dev": true,
-          "requires": {
-            "@smithy/types": "^2.1.0",
-            "tslib": "^2.5.0"
-          }
-        },
         "brace-expansion": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -38982,9 +48127,9 @@
       }
     },
     "tslib": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -39997,9 +49142,9 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
     "zod": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.18.0.tgz",
-      "integrity": "sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA=="
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="
     },
     "zod-validation-error": {
       "version": "1.3.0",

--- a/packages/basti/package.json
+++ b/packages/basti/package.json
@@ -41,17 +41,17 @@
     "ts-node": "10.9.1"
   },
   "dependencies": {
-    "@aws-sdk/client-ec2": "3.231.0",
-    "@aws-sdk/client-elasticache": "3.398.0",
-    "@aws-sdk/client-iam": "3.231.0",
-    "@aws-sdk/client-rds": "3.231.0",
-    "@aws-sdk/client-ssm": "3.231.0",
+    "@aws-sdk/client-ec2": "3.645.0",
+    "@aws-sdk/client-elasticache": "3.645.0",
+    "@aws-sdk/client-iam": "3.645.0",
+    "@aws-sdk/client-rds": "3.645.0",
+    "@aws-sdk/client-ssm": "3.645.0",
     "chalk": "5.0.1",
     "cosmiconfig": "8.1.3",
     "inquirer": "9.0.0",
     "ora": "6.1.2",
     "yargs": "17.7.2",
-    "zod": "3.18.0",
+    "zod": "3.23.8",
     "zod-validation-error": "1.3.0"
   },
   "optionalDependencies": {

--- a/packages/basti/src/aws/common/waiter-config.ts
+++ b/packages/basti/src/aws/common/waiter-config.ts
@@ -1,6 +1,4 @@
-import type { WaiterConfiguration } from '@aws-sdk/util-waiter';
-
-export const COMMON_WAITER_CONFIG: Omit<WaiterConfiguration<any>, 'client'> = {
+export const COMMON_WAITER_CONFIG = {
   minDelay: 2,
   maxDelay: 2,
   maxWaitTime: 600,

--- a/packages/basti/src/aws/ec2/create-ec2-instance.ts
+++ b/packages/basti/src/aws/ec2/create-ec2-instance.ts
@@ -14,6 +14,7 @@ import { AwsInstanceProfileNotFoundError } from './ec2-errors.js';
 import { parseEc2InstanceResponse } from './parse-ec2-response.js';
 import { ec2Client } from './ec2-client.js';
 
+import type { _InstanceType } from '@aws-sdk/client-ec2';
 import type { AwsEc2Instance } from './types/aws-ec2-instance.js';
 import type { AwsTag } from '../tags/types.js';
 
@@ -74,7 +75,7 @@ export async function createEc2Instance({
           ],
 
           ImageId: imageId,
-          InstanceType: instanceType,
+          InstanceType: instanceType as _InstanceType,
 
           IamInstanceProfile: {
             Name: instanceProfile.name,

--- a/packages/basti/src/aws/tags/utils/to-tag-specification.ts
+++ b/packages/basti/src/aws/tags/utils/to-tag-specification.ts
@@ -1,4 +1,4 @@
-import type { TagSpecification } from '@aws-sdk/client-ec2';
+import type { ResourceType, TagSpecification } from '@aws-sdk/client-ec2';
 import type { AwsTag } from '../types.js';
 
 export function toTagSpecification(
@@ -6,7 +6,7 @@ export function toTagSpecification(
   tags: AwsTag[]
 ): TagSpecification {
   return {
-    ResourceType: resourceType,
+    ResourceType: resourceType as ResourceType,
     Tags: tags.map(tag => ({
       Key: tag.key,
       Value: tag.value,


### PR DESCRIPTION
## Proposed Changes

This PR updates some dependencies of the Basti CLI package to mitigate possible security vulnerabilities:

1. `@aws-sdk/*` packages from `3.231.0` to `3.645.0`.
2. `zod` from `3.18.0` to `3.23.8`.

## Related Issues/PRs

[If there are any related issues or pull requests, please link to them here.]

## Checklist

- [x] I cleaned up my code.
- [x] All the tests and checks passed (`npm run test`).
- [x] I have added necessary documentation and/or updated existing documentation. <!-- check if not applicable -->
- [x] I have added or modified tests to cover the changes. <!-- check if not applicable -->