### PR TITLE
feat(many): make bastion public ip address configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@
 
 <!-- The following toc is generated with the Markdown All in One VSCode extension (https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one) -->
 <!-- omit from toc -->
+
 ## Table of contents
+
 - [💡 Why Basti?](#-why-basti)
 - [⚙️ How it works](#️-how-it-works)
 - [💻 Installation](#-installation)
@@ -64,7 +66,6 @@
 
 <br/>
 
-
 ## 💡 Why Basti?
 
 With [Basti](https://github.com/basti-app/basti), you can securely connect to RDS, Aurora, Elasticache, or any other AWS resources in private VPC subnets from a local machine or a CI/CD pipeline almost for free!
@@ -73,7 +74,7 @@ With [Basti](https://github.com/basti-app/basti), you can securely connect to RD
 
 - 🦾 With Session Manager, you need to oversee an EC2 bastion instance for connecting to managed resources such as RDS or Elasticache. Basti handles bastion instance setup, shutdown, and updates for you!
 
-- 💅 Basti provides a convenient way to store and reuse connection configuration across your team. 
+- 💅 Basti provides a convenient way to store and reuse connection configuration across your team.
 
 - 📶 Basti improves stability of the Session Manager sessions by automatically restarting failed or expired sessions.
 
@@ -163,9 +164,9 @@ To connect to a custom target, select the `Custom` option when prompted for a ta
 
 ## 🎛️ Advanced initialization options
 
-The `basti init` command has a number of advanced options that can be used to customize the bastion instance and other resources created by Basti. 
+The `basti init` command has a number of advanced options that can be used to customize the bastion instance and other resources created by Basti.
 
-> 💡 Please, refer to the [reference documentation](https://github.com/basti-app/basti/blob/main/docs/reference/cli.md#basti-init-command) for the full list of options. 
+> 💡 Please, refer to the [reference documentation](https://github.com/basti-app/basti/blob/main/docs/reference/cli.md#basti-init-command) for the full list of options.
 
 ### Resource tags
 
@@ -192,6 +193,16 @@ Tags with the same name will be overwritten in the order they are specified. Tag
 
 You can specify the EC2 instance type to be used for the bastion instance using the `--bastion-instance-type` option or by entering it in the advanced options section of the interactive mode. The default instance type is `t2.micro`, but it's subject to change in the future.
 
+### Assign public IP address
+
+By default, the bastion instance is created with a public IP address to enable seamless **outbound-only** connection to AWS services from a public VPC subnet. Please, refer to the [AWS documentation](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-prerequisites.html) for more details on the Session Manager requirements.
+
+You can disable the public IP address using the `--bastion-assign-public-ip false` option or in the advanced options section of the interactive mode.
+
+> ☝️ When the public IP address is disabled, you will need to manually ensure that the AWS Session Manager [connectivity requirements](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-prerequisites.html) are met. This can be done with the help of VPC endpoints, NAT gateways, or other means.
+
+> 💡 Disabling public IP address can be useful when setting up the bastion instance in a private subnet.
+
 ## 🦾 Automatic mode
 
 Using interactive mode is convenient when you're getting used to Basti. However, in Continuous Integration and Continuous Delivery (CI/CD) pipelines, you will probably want to disable interactivity and pass all the options as command line arguments:
@@ -212,8 +223,8 @@ wait-on tcp:localhost:your-port
 ## 📝 Configuration file
 
 When working with multiple connection targets, it becomes convenient to store their configurations
-and other Basti settings in a dedicated configuration file. To facilitate this, Basti automatically 
-searches for the configuration file in the current directory and its parent directories. 
+and other Basti settings in a dedicated configuration file. To facilitate this, Basti automatically
+searches for the configuration file in the current directory and its parent directories.
 The supported file names are `.basti.yaml`, `.basti.yml`, and `.basti.json`.
 
 You can quickly start a connection defined in the configuration file by passing its
@@ -269,7 +280,7 @@ targets:
 
 </details>
 
-> 💡 Please, refer to the [reference documentation](https://github.com/basti-app/basti/blob/main/docs/reference/configuration-file.md) for the full list of configuration options. 
+> 💡 Please, refer to the [reference documentation](https://github.com/basti-app/basti/blob/main/docs/reference/configuration-file.md) for the full list of configuration options.
 
 ## 💫 Infrastructure as code (IaC)
 
@@ -324,9 +335,9 @@ Minimal policy:
         "arn:aws:ec2:<your-region>:<your-account-id>:instance/<your-basti-instance-id>"
       ],
       "Condition": {
-          "BoolIfExists": {
-              "ssm:SessionDocumentAccessCheck": "true"
-          }
+        "BoolIfExists": {
+          "ssm:SessionDocumentAccessCheck": "true"
+        }
       }
     }
   ]
@@ -342,6 +353,7 @@ Since Basti uses IAM for access control, the connection history, along with the 
 A simple connections history can also be found in the AWS Session Manager history. See [AWS Session Manager documentation](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-view-history.html) for more details.
 
 ### Shared configuration
+
 The [Basti configuration file](#basti-configuration-file) file can be shared across your organization, making it easy for all developers to connect to the project's cloud infrastructure. A recommended practice is to store the configuration file in the root of your project's repository. This ensures that the configuration is readily accessible to all team members, enabling quick and seamless connections to the required cloud resources.
 
 ## 🔐 Security
@@ -385,12 +397,14 @@ npm run build
 Full Basti build consists of two parts:
 
 1. Compiling Basti TypeScript code. The code has to be compiled after each change.
+
    ```sh
    npm run build-src
 
    # Or, if you want to automatically recompile on each change:
    npm run build-src-watch
    ```
+
 2. Building non-NodeJS dependencies (AWS session-manger-plugin).
    This step is only required after the first checkout or in a rare
    case when the dependencies are updated.

--- a/packages/basti-cdk/README.md
+++ b/packages/basti-cdk/README.md
@@ -31,7 +31,9 @@
 
 <!-- The following toc is generated with the Markdown All in One VSCode extension (https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one) -->
 <!-- omit from toc -->
+
 ## Table of contents
+
 - [Why Basti?](#why-basti)
 - [How it works](#how-it-works)
 - [Installation](#installation)
@@ -103,54 +105,44 @@ import { BastiAccessSecurityGroup, BastiInstance } from 'basti-cdk';
 Use `BastiInstance` construct to create Basti EC2 instance.
 
 ```ts
-const bastiInstance = new BastiInstance(
-  stack,
-  'BastiInstance',
-  {
-    vpc,
-    
-    // Optional. Randomly generated if omitted.
-    // Used to name the EC2 instance and other resources.
-    // The resulting name will be "basti-instance-my-bastion"
-    bastiId: 'my-bastion'
-  }
-);
+const bastiInstance = new BastiInstance(stack, 'BastiInstance', {
+  vpc,
+
+  // Optional. Randomly generated if omitted.
+  // Used to name the EC2 instance and other resources.
+  // The resulting name will be "basti-instance-my-bastion"
+  bastiId: 'my-bastion',
+});
 ```
 
 ### Allow connection to target
 
-Use `BastiAccessSecurityGroup` construct to create a security group for your target. This security group will allow the Basti instance to connect to the target. 
+Use `BastiAccessSecurityGroup` construct to create a security group for your target. This security group will allow the Basti instance to connect to the target.
 
 ```ts
 // Create a security group for your target
 const bastiAccessSecurityGroup = new BastiAccessSecurityGroup(
   stack,
-  'BastiAccessSecurityGroup', 
+  'BastiAccessSecurityGroup',
   {
     vpc,
 
     // Optional. Randomly generated if omitted.
     // Used to name the security group and other resources.
     // The resulting name will be "basti-access-my-target"
-    bastiId: 'my-target'
+    bastiId: 'my-target',
   }
 );
 
 // Create the target
-const rdsInstance = new aws_rds.DatabaseInstance(
-  stack,
-  'RdsInstance',
-  {
-    // Unrelated properties are omitted for brevity
+const rdsInstance = new aws_rds.DatabaseInstance(stack, 'RdsInstance', {
+  // Unrelated properties are omitted for brevity
 
-    vpc,
-    port: 5432,
+  vpc,
+  port: 5432,
 
-    securityGroups: [
-      bastiAccessSecurityGroup
-    ]
-  }
-);
+  securityGroups: [bastiAccessSecurityGroup],
+});
 
 // Allow the Basti instance to connect to the target on the specified port
 bastiAccessSecurityGroup.allowBastiInstanceConnection(
@@ -176,15 +168,15 @@ When sharing a Basti instance across stacks, you can just pass it as a property 
 ```ts
 // Most likely, the VPC was created separately as well
 const vpc = aws_ec2.Vpc.fromLookup(stack, 'Vpc', {
-    vpcName: 'existing-vpc-id',
+  vpcName: 'existing-vpc-id',
 });
 
 const bastiInstance = BastiInstance.fromBastiId(
-    this,
-    'BastiInstance',
-    // The BastiID of the Basti instance you want to import
-    'existing-basti-id',
-    vpc
+  this,
+  'BastiInstance',
+  // The BastiID of the Basti instance you want to import
+  'existing-basti-id',
+  vpc
 );
 
 // bastiInstance can now be used to allow access to a connection target

--- a/packages/basti-cdk/src/basti-instance.ts
+++ b/packages/basti-cdk/src/basti-instance.ts
@@ -53,6 +53,12 @@ export interface BastiInstanceProps {
    * @default Latest Amazon Linux 2 - Kernel 5.10
    */
   readonly machineImage?: aws_ec2.IMachineImage;
+
+  /**
+   * (Optional) Whether to assign a public IP address to the bastion instance.
+   * If not specified, falls back to the default behavior of the VPC.
+   */
+  readonly assignPublicIp?: boolean;
 }
 
 export interface IBastiInstance {
@@ -170,6 +176,7 @@ export class BastiInstance extends Construct implements IBastiInstance {
       instanceName: `${BASTION_INSTANCE_NAME_PREFIX}-${this.bastiId}`,
       machineImage: props.machineImage ?? defaultMachineImage,
       instanceType: props.instanceType ?? defaultInstanceType,
+      associatePublicIpAddress: props.assignPublicIp,
       role: this.role,
       securityGroup: this.securityGroup,
       requireImdsv2: true,

--- a/packages/basti/README.md
+++ b/packages/basti/README.md
@@ -37,7 +37,9 @@
 
 <!-- The following toc is generated with the Markdown All in One VSCode extension (https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one) -->
 <!-- omit from toc -->
+
 ## Table of contents
+
 - [💡 Why Basti?](#-why-basti)
 - [⚙️ How it works](#️-how-it-works)
 - [💻 Installation](#-installation)
@@ -70,7 +72,6 @@
 
 <br/>
 
-
 ## 💡 Why Basti?
 
 With [Basti](https://github.com/basti-app/basti), you can securely connect to RDS, Aurora, Elasticache, or any other AWS resources in private VPC subnets from a local machine or a CI/CD pipeline almost for free!
@@ -79,7 +80,7 @@ With [Basti](https://github.com/basti-app/basti), you can securely connect to RD
 
 - 🦾 With Session Manager, you need to oversee an EC2 bastion instance for connecting to managed resources such as RDS or Elasticache. Basti handles bastion instance setup, shutdown, and updates for you!
 
-- 💅 Basti provides a convenient way to store and reuse connection configuration across your team. 
+- 💅 Basti provides a convenient way to store and reuse connection configuration across your team.
 
 - 📶 Basti improves stability of the Session Manager sessions by automatically restarting failed or expired sessions.
 
@@ -169,9 +170,9 @@ To connect to a custom target, select the `Custom` option when prompted for a ta
 
 ## 🎛️ Advanced initialization options
 
-The `basti init` command has a number of advanced options that can be used to customize the bastion instance and other resources created by Basti. 
+The `basti init` command has a number of advanced options that can be used to customize the bastion instance and other resources created by Basti.
 
-> 💡 Please, refer to the [reference documentation](https://github.com/basti-app/basti/blob/main/docs/reference/cli.md#basti-init-command) for the full list of options. 
+> 💡 Please, refer to the [reference documentation](https://github.com/basti-app/basti/blob/main/docs/reference/cli.md#basti-init-command) for the full list of options.
 
 ### Resource tags
 
@@ -198,6 +199,16 @@ Tags with the same name will be overwritten in the order they are specified. Tag
 
 You can specify the EC2 instance type to be used for the bastion instance using the `--bastion-instance-type` option or by entering it in the advanced options section of the interactive mode. The default instance type is `t2.micro`, but it's subject to change in the future.
 
+### Assign public IP address
+
+By default, the bastion instance is created with a public IP address to enable seamless **outbound-only** connection to AWS services from a public VPC subnet. Please, refer to the [AWS documentation](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-prerequisites.html) for more details on the Session Manager requirements.
+
+You can disable the public IP address using the `--bastion-assign-public-ip false` option or in the advanced options section of the interactive mode.
+
+> ☝️ When the public IP address is disabled, you will need to manually ensure that the AWS Session Manager [connectivity requirements](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-prerequisites.html) are met. This can be done with the help of VPC endpoints, NAT gateways, or other means.
+
+> 💡 Disabling public IP address can be useful when setting up the bastion instance in a private subnet.
+
 ## 🦾 Automatic mode
 
 Using interactive mode is convenient when you're getting used to Basti. However, in Continuous Integration and Continuous Delivery (CI/CD) pipelines, you will probably want to disable interactivity and pass all the options as command line arguments:
@@ -218,8 +229,8 @@ wait-on tcp:localhost:your-port
 ## 📝 Configuration file
 
 When working with multiple connection targets, it becomes convenient to store their configurations
-and other Basti settings in a dedicated configuration file. To facilitate this, Basti automatically 
-searches for the configuration file in the current directory and its parent directories. 
+and other Basti settings in a dedicated configuration file. To facilitate this, Basti automatically
+searches for the configuration file in the current directory and its parent directories.
 The supported file names are `.basti.yaml`, `.basti.yml`, and `.basti.json`.
 
 You can quickly start a connection defined in the configuration file by passing its
@@ -275,7 +286,7 @@ targets:
 
 </details>
 
-> 💡 Please, refer to the [reference documentation](https://github.com/basti-app/basti/blob/main/docs/reference/configuration-file.md) for the full list of configuration options. 
+> 💡 Please, refer to the [reference documentation](https://github.com/basti-app/basti/blob/main/docs/reference/configuration-file.md) for the full list of configuration options.
 
 ## 💫 Infrastructure as code (IaC)
 
@@ -330,9 +341,9 @@ Minimal policy:
         "arn:aws:ec2:<your-region>:<your-account-id>:instance/<your-basti-instance-id>"
       ],
       "Condition": {
-          "BoolIfExists": {
-              "ssm:SessionDocumentAccessCheck": "true"
-          }
+        "BoolIfExists": {
+          "ssm:SessionDocumentAccessCheck": "true"
+        }
       }
     }
   ]
@@ -348,6 +359,7 @@ Since Basti uses IAM for access control, the connection history, along with the 
 A simple connections history can also be found in the AWS Session Manager history. See [AWS Session Manager documentation](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-view-history.html) for more details.
 
 ### Shared configuration
+
 The [Basti configuration file](#basti-configuration-file) file can be shared across your organization, making it easy for all developers to connect to the project's cloud infrastructure. A recommended practice is to store the configuration file in the root of your project's repository. This ensures that the configuration is readily accessible to all team members, enabling quick and seamless connections to the required cloud resources.
 
 ## 🔐 Security
@@ -391,12 +403,14 @@ npm run build
 Full Basti build consists of two parts:
 
 1. Compiling Basti TypeScript code. The code has to be compiled after each change.
+
    ```sh
    npm run build-src
 
    # Or, if you want to automatically recompile on each change:
    npm run build-src-watch
    ```
+
 2. Building non-NodeJS dependencies (AWS session-manger-plugin).
    This step is only required after the first checkout or in a rare
    case when the dependencies are updated.

--- a/packages/basti/src/bastion/bastion.ts
+++ b/packages/basti/src/bastion/bastion.ts
@@ -28,3 +28,4 @@ export const BASTION_INSTANCE_UPDATING_TAG_NAME = 'basti:updating';
 export const BASTION_INSTANCE_UPDATED_TAG_NAME = 'basti:updated';
 
 export const BASTION_INSTANCE_DEFAULT_INSTANCE_TYPE = 't2.micro';
+export const BASTION_INSTANCE_DEFAULT_ASSIGN_PUBLIC_IP = true;

--- a/packages/basti/src/bastion/create-bastion.ts
+++ b/packages/basti/src/bastion/create-bastion.ts
@@ -23,6 +23,7 @@ import {
   BASTION_INSTANCE_PROFILE_PATH_PREFIX,
   BASTION_INSTANCE_SECURITY_GROUP_NAME_PREFIX,
   BASTION_INSTANCE_DEFAULT_INSTANCE_TYPE,
+  BASTION_INSTANCE_DEFAULT_ASSIGN_PUBLIC_IP,
 } from './bastion.js';
 
 import type { Bastion } from './bastion.js';
@@ -47,6 +48,7 @@ export interface CreateBastionInput {
   vpcId: string;
   subnetId: string;
   instanceType: string | undefined;
+  assignPublicIp: boolean | undefined;
   tags: AwsTag[];
   hooks?: CreateBastionHooks;
 }
@@ -55,6 +57,7 @@ export async function createBastion({
   vpcId,
   subnetId,
   instanceType,
+  assignPublicIp,
   tags,
   hooks,
 }: CreateBastionInput): Promise<Bastion> {
@@ -78,6 +81,7 @@ export async function createBastion({
     subnetId,
     bastionSecurityGroup,
     instanceType,
+    assignPublicIp,
     tags,
     hooks
   );
@@ -189,6 +193,7 @@ async function createBastionInstance(
   subnetId: string,
   bastionSecurityGroup: AwsSecurityGroup,
   instanceType: string | undefined,
+  assignPublicIp: boolean | undefined,
   tags: AwsTag[],
   hooks?: CreateBastionHooks
 ): Promise<AwsEc2Instance> {
@@ -201,7 +206,8 @@ async function createBastionInstance(
       roleNames: [bastionRole.name],
       profilePathPrefix: BASTION_INSTANCE_PROFILE_PATH_PREFIX,
       subnetId,
-      assignPublicIp: true,
+      assignPublicIp:
+        assignPublicIp ?? BASTION_INSTANCE_DEFAULT_ASSIGN_PUBLIC_IP,
       securityGroupIds: [bastionSecurityGroup.id],
       userData: BASTION_INSTANCE_CLOUD_INIT,
       requireIMDSv2: true,

--- a/packages/basti/src/cli/commands/init/advanced-input/select-advanced-input.ts
+++ b/packages/basti/src/cli/commands/init/advanced-input/select-advanced-input.ts
@@ -7,6 +7,7 @@ import {
   isAdvancedInputComplete,
 } from '../init-command-input.js';
 
+import { selectAssignPublicIp } from './select-assign-public-ip.js';
 import { selectInstanceType } from './select-instance-type.js';
 import { selectTags } from './select-tags.js';
 
@@ -30,10 +31,12 @@ export async function selectAdvancedInput(
   }
 
   const instanceType = await selectInstanceType(input.instanceType);
+  const assignPublicIp = await selectAssignPublicIp(input.assignPublicIp);
   const tags = await selectTags(input.tags);
 
   return {
     instanceType,
+    assignPublicIp,
     tags,
   };
 }

--- a/packages/basti/src/cli/commands/init/advanced-input/select-assign-public-ip.ts
+++ b/packages/basti/src/cli/commands/init/advanced-input/select-assign-public-ip.ts
@@ -1,0 +1,19 @@
+import { BASTION_INSTANCE_DEFAULT_ASSIGN_PUBLIC_IP } from '#src/bastion/bastion.js';
+import { cli } from '#src/common/cli.js';
+
+export async function selectAssignPublicIp(
+  assignPublicIpInput: boolean | undefined
+): Promise<boolean> {
+  if (assignPublicIpInput !== undefined) {
+    return assignPublicIpInput;
+  }
+
+  const { assignPublicIp } = await cli.prompt({
+    type: 'confirm',
+    name: 'assignPublicIp',
+    message: 'Assign a public IP to the bastion?',
+    default: BASTION_INSTANCE_DEFAULT_ASSIGN_PUBLIC_IP,
+  });
+
+  return assignPublicIp;
+}

--- a/packages/basti/src/cli/commands/init/create-bastion.ts
+++ b/packages/basti/src/cli/commands/init/create-bastion.ts
@@ -19,6 +19,7 @@ export interface CreateBastionInput {
   vpcId: string;
   subnetId: string;
   instanceType: string | undefined;
+  assignPublicIp: boolean | undefined;
   tags: AwsTag[];
 }
 
@@ -26,6 +27,7 @@ export async function createBastion({
   vpcId,
   subnetId,
   instanceType,
+  assignPublicIp,
   tags,
 }: CreateBastionInput): Promise<Bastion> {
   const subCli = cli.createSubInstance({ indent: 2 });
@@ -36,6 +38,7 @@ export async function createBastion({
       vpcId,
       subnetId,
       instanceType,
+      assignPublicIp,
       tags,
       hooks: {
         onRetrievingImageId: () =>

--- a/packages/basti/src/cli/commands/init/init-command-input.ts
+++ b/packages/basti/src/cli/commands/init/init-command-input.ts
@@ -10,6 +10,7 @@ export interface InitCommandRequiredInput {
 export interface InitCommandAdvancedInput {
   tags: AwsTag[];
   instanceType?: string;
+  assignPublicIp?: boolean;
 }
 
 export type InitCommandInput = InitCommandRequiredInput &
@@ -20,5 +21,9 @@ export function isRequiredInputComplete(input: InitCommandInput): boolean {
 }
 
 export function isAdvancedInputComplete(input: InitCommandInput): boolean {
-  return input.tags.length > 0 && input.instanceType !== undefined;
+  return (
+    input.tags.length > 0 &&
+    input.instanceType !== undefined &&
+    input.assignPublicIp !== undefined
+  );
 }

--- a/packages/basti/src/cli/commands/init/init.ts
+++ b/packages/basti/src/cli/commands/init/init.ts
@@ -28,6 +28,7 @@ export async function handleInit(input: InitCommandInput): Promise<void> {
       vpcId: targetVpcId,
       subnetId: bastionSubnet,
       instanceType: advancedInput.instanceType,
+      assignPublicIp: advancedInput.assignPublicIp,
       tags: advancedInput.tags,
     }));
 

--- a/packages/basti/src/cli/commands/init/select-bastion-subnet.ts
+++ b/packages/basti/src/cli/commands/init/select-bastion-subnet.ts
@@ -25,7 +25,7 @@ async function promptForBastionSubnetId(vpcId: string): Promise<string> {
 
   if (subnets.length === 0) {
     throw new EarlyExitError(
-      'No subnets found in the VPC. Vpc must have at least one public subnet for the bastion to be set up'
+      'No subnets found in the VPC. Vpc must have at least one subnet for the bastion to be set up'
     );
   }
 
@@ -35,7 +35,8 @@ async function promptForBastionSubnetId(vpcId: string): Promise<string> {
     message:
       fmt.reset('Select ') +
       fmt.important('public') +
-      fmt.reset(' subnet for the bastion'),
+      fmt.reset(' subnet for the bastion.') +
+      fmt.gray('\n  (See docs for setting up bastion in a private subnet)'),
     choices: subnets.map(subnet => ({
       name: fmt.resourceName(subnet),
       value: subnet.id,

--- a/packages/basti/src/cli/run.ts
+++ b/packages/basti/src/cli/run.ts
@@ -67,6 +67,10 @@ void yargs(hideBin(process.argv))
           type: 'string',
           description: 'EC2 instance type for the bastion instance',
         })
+        .option('bastion-assign-public-ip', {
+          type: 'boolean',
+          description: 'Assign a public IP address to the bastion instance',
+        })
         .option('tag', {
           type: 'string',
           description:

--- a/packages/basti/src/cli/yargs/get-command-input.ts
+++ b/packages/basti/src/cli/yargs/get-command-input.ts
@@ -44,6 +44,7 @@ export type InitOptions = Partial<RdsInstanceOptions> &
   Partial<CustomTargetVpcOptions> & {
     bastionSubnet?: string;
     bastionInstanceType?: string;
+    bastionAssignPublicIp?: boolean;
   } & TagOptions;
 
 export type ConnectOptions = Partial<RdsInstanceOptions> &
@@ -88,6 +89,7 @@ export function getInitCommandInputFromOptions(
     bastionSubnet: options.bastionSubnet,
     tags: getTagsFromOptions(options),
     instanceType: options.bastionInstanceType,
+    assignPublicIp: options.bastionAssignPublicIp,
   };
 }
 


### PR DESCRIPTION
## Proposed Changes

This PR adds `--bastion-assign-public-ip` CLI option and a corresponding advanced option in the interactive mode.

A corresponding `assignPublicIp` option is also added to the `BastiInstance` construct in Basti CDK.

## Related Issues/PRs

#103 

## Checklist

- [x] I cleaned up my code.
- [x] All the tests and checks passed (`npm run test`).
- [x] I have added necessary documentation and/or updated existing documentation. <!-- check if not applicable -->
- [x] I have added or modified tests to cover the changes. <!-- check if not applicable -->