### PR TITLE
fix(basti-cdk): unblock basti instance role update

### DIFF
--- a/packages/basti-cdk/src/__test__/basti-instance.test.ts
+++ b/packages/basti-cdk/src/__test__/basti-instance.test.ts
@@ -31,7 +31,7 @@ describe('BastiInstanceTest', () => {
     });
 
     template.hasResourceProperties('AWS::IAM::Role', {
-      RoleName: 'basti-instance-d8b7dc8b',
+      RoleName: 'basti-instance-d8b7dc8b-v2',
       AssumeRolePolicyDocument: {
         Statement: [
           {
@@ -163,7 +163,7 @@ describe('BastiInstanceTest', () => {
     });
 
     template.hasResourceProperties('AWS::IAM::Role', {
-      RoleName: 'basti-instance-TEST_ID',
+      RoleName: 'basti-instance-TEST_ID-v2',
       AssumeRolePolicyDocument: {
         Statement: [
           {

--- a/packages/basti-cdk/src/basti-instance.ts
+++ b/packages/basti-cdk/src/basti-instance.ts
@@ -147,7 +147,7 @@ export class BastiInstance extends Construct implements IBastiInstance {
 
     this.role = new aws_iam.Role(this, 'IamRoleBastionInstance', {
       assumedBy: new aws_iam.ServicePrincipal('ec2.amazonaws.com'),
-      roleName: `${BASTION_INSTANCE_ROLE_NAME_PREFIX}-${this.bastiId}`,
+      roleName: `${BASTION_INSTANCE_ROLE_NAME_PREFIX}-${this.bastiId}-v2`,
       path: `${BASTION_INSTANCE_ROLE_PATH_PREFIX}/${region}/`,
       inlinePolicies: {
         'session-manager-access': sessionManagerPolicy,


### PR DESCRIPTION
## Proposed Changes

This PR unblocks Basti instance IAM role update after a [recent change](https://github.com/basti-app/basti/pull/109/files#diff-b5a46dba7e3da24b7e9a6416e5dd8cc03c8ca8399d5ac09dc942d8aa71faa1fbR145) that requires the role replacement by updating the role custom name. Similar `vX` prefixes will be added to other resources with custom names in the future as needed.

## Related Issues/PRs

Reported in #117

## Checklist

- [x] I cleaned up my code.
- [x] All the tests and checks passed (`npm run test`).
- [x] I have added necessary documentation and/or updated existing documentation. <!-- check if not applicable -->
- [x] I have added or modified tests to cover the changes. <!-- check if not applicable -->