### PR TITLE
fix(basti): Cleanup - Prevent attempting to remove a security group from a cluster db instance

### DIFF
--- a/packages/basti/src/cleanup/security-group-cleaner.ts
+++ b/packages/basti/src/cleanup/security-group-cleaner.ts
@@ -45,8 +45,10 @@ async function cleanupDbInstanceReferences(
 ): Promise<void> {
   const dbInstances = await getDbInstances();
 
-  const dbInstancesWithReferences = dbInstances.filter(instance =>
-    arrayContains(instance.securityGroupIds, securityGroupIds)
+  const dbInstancesWithReferences = dbInstances.filter(
+    instance =>
+      instance.clusterIdentifier === undefined &&
+      arrayContains(instance.securityGroupIds, securityGroupIds)
   );
   if (dbInstancesWithReferences.length === 0) {
     return;


### PR DESCRIPTION
## Proposed Changes

This PR fixes the issue of attempting to remove a db instance security group that is part of a cluster in basti cleanup.

security-group-cleaner.ts removes the security group from the cluster and then tries to remove it from the instance causing a 400 error.

"InvalidParameterCombination: The specified DB Instance is a member of a cluster. Modify vpc security group for the DB Cluster using the ModifyDbCluster API"

This PR checks that the db instance doesn't have a cluster identifier before attempting to remove the security group.

## Checklist

- [x] I cleaned up my code.
- [x] All the tests and checks passed (`npm run test`).
- [x] I have added necessary documentation and/or updated existing documentation. <!-- check if not applicable -->
- [x] I have added or modified tests to cover the changes. <!-- check if not applicable -->